### PR TITLE
Fix: querybuilder updates

### DIFF
--- a/.changeset/gold-bees-smile.md
+++ b/.changeset/gold-bees-smile.md
@@ -1,5 +1,5 @@
 ---
-"@accelint/design-system": minor
+"@accelint/design-system": patch
 ---
 
-patch: fix small bug where classnames didn't propagate
+Fixed bug where classnames didn't propagate for query builder component.

--- a/.changeset/gold-bees-smile.md
+++ b/.changeset/gold-bees-smile.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-system": minor
+---
+
+patch: fix small bug where classnames didn't propagate

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist
 # Environment variables
 .env
 
+# ide files
+*.iml
+.idea
+
+

--- a/packages/design-system/src/components/query-builder/group.tsx
+++ b/packages/design-system/src/components/query-builder/group.tsx
@@ -115,7 +115,6 @@ export function RuleGroup(props: RuleGroupProps) {
       <div
         ref={group.previewRef}
         className={group.outerClassName}
-        title={group.accessibleDescription}
         data-dragmonitorid={group.dragMonitorId}
         data-dropmonitorid={group.dropMonitorId}
         data-level={group.path.length}

--- a/packages/design-system/src/components/query-builder/group.tsx
+++ b/packages/design-system/src/components/query-builder/group.tsx
@@ -10,7 +10,7 @@ import {
   useRuleGroup,
   useStopEventPropagation,
 } from 'react-querybuilder';
-import { inlineVars } from '@/utils';
+import { inlineVars } from '../../utils';
 import { QueryBuilderContext } from './constants';
 import { queryBuilderGroupStateVars } from './query-builder.css';
 import type { RuleGroupElementsProps } from './types';

--- a/packages/design-system/src/components/query-builder/group.tsx
+++ b/packages/design-system/src/components/query-builder/group.tsx
@@ -10,7 +10,7 @@ import {
   useRuleGroup,
   useStopEventPropagation,
 } from 'react-querybuilder';
-import { inlineVars } from '../../utils';
+import { inlineVars } from '@/utils';
 import { QueryBuilderContext } from './constants';
 import { queryBuilderGroupStateVars } from './query-builder.css';
 import type { RuleGroupElementsProps } from './types';

--- a/packages/design-system/src/components/query-builder/query-builder.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.tsx
@@ -56,6 +56,7 @@ const defaultMapping: QueryBuilderMapping = {
 };
 
 export function QueryBuilder({
+  classNames: classNamesProp,
   consistentColumns = true,
   controlElements: controlElementsProp,
   disabled,
@@ -77,10 +78,15 @@ export function QueryBuilder({
 
   const classNames = useMemo(
     () =>
-      mergeClassNames(queryBuilderClassNames, theme.QueryBuilder, {
-        rule: { error: mapping?.error?.[size] },
-      }),
-    [mapping?.error, size, theme.QueryBuilder],
+      mergeClassNames(
+        queryBuilderClassNames,
+        theme.QueryBuilder,
+        classNamesProp,
+        {
+          rule: { error: mapping?.error?.[size] },
+        }
+      ),
+    [mapping?.error, size, theme.QueryBuilder, classNamesProp]
   );
 
   const controlClassNames = useMemo(() => {

--- a/packages/design-system/src/components/query-builder/query-builder.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { Provider } from 'react-aria-components';
 import { QueryBuilder as RQBuilder } from 'react-querybuilder';
-import { useTheme } from '@/hooks';
-import { bodies } from '@/styles';
-import { inlineVars, mergeClassNames } from '@/utils';
+import { useTheme } from '../../hooks';
+import { bodies } from '../../styles';
+import { inlineVars, mergeClassNames } from '../../utils';
 import { ButtonContext, type ButtonProps } from '../button';
 import { CheckboxContext, type CheckboxProps } from '../checkbox';
 import { InputContext, type InputProps } from '../input';

--- a/packages/design-system/src/components/query-builder/query-builder.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { Provider } from 'react-aria-components';
 import { QueryBuilder as RQBuilder } from 'react-querybuilder';
-import { useTheme } from '../../hooks';
-import { bodies } from '../../styles';
-import { inlineVars, mergeClassNames } from '../../utils';
+import { useTheme } from '@/hooks';
+import { bodies } from '@/styles';
+import { inlineVars, mergeClassNames } from '@/utils';
 import { ButtonContext, type ButtonProps } from '../button';
 import { CheckboxContext, type CheckboxProps } from '../checkbox';
 import { InputContext, type InputProps } from '../input';


### PR DESCRIPTION
Small update for the querybuilder component to ensure classnames are merged in and passed to children. 

From this MR while it still has c2ds embedded in the application context: https://gitlab-cbc2.cce.af.mil/abms/cbc2/jeric2o/jeric2o/-/merge_requests/702