### PR TITLE
Fix/ds vanilla export

### DIFF
--- a/.changeset/plenty-planets-act.md
+++ b/.changeset/plenty-planets-act.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-system": patch
+---
+
+Fixed vanilla export by including all types

--- a/packages/design-system/rollup.config.js
+++ b/packages/design-system/rollup.config.js
@@ -96,7 +96,7 @@ function bundleVanilla(ext) {
   return {
     name: 'bundle-vanilla-emits',
     generateBundle(_, bundle) {
-      const source = bundle['index.js'].code;
+      const source = `${bundle['index.js'].code}\n${bundle['index.d.ts']?.source}`;
 
       this.emitFile({
         type: 'asset',
@@ -106,6 +106,7 @@ function bundleVanilla(ext) {
           .split('\n')
           .filter(
             (line) =>
+              line.startsWith('export type') ||
               line.endsWith(`.vanilla.js';`) ||
               line.endsWith(`/types.js';`) ||
               line.endsWith(`'./utils/css.js';`) ||


### PR DESCRIPTION
Updated DS build with a quick fix (possible full rewrite to come at a later time) to include all types in the `vanilla.d.ts` export