### PR TITLE
Enable --watch with filter at top level

### DIFF
--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -24,7 +24,7 @@
     "dev": "pnpm tsc --watch",
     "index": "pnpm zx ../../scripts/indexer.mjs packages/converters",
     "lint": "pnpm biome lint ./",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/typescript-config": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "dev": "pnpm tsc --watch",
     "index": "pnpm zx ../../scripts/indexer.mjs packages/core",
     "lint": "pnpm biome lint ./",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/typescript-config": "workspace:*",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -35,7 +35,7 @@
     "index": "pnpm zx ../../scripts/indexer.mjs packages/design-system --barrels",
     "lint:todo": "pnpm biome lint ./",
     "preview": "pnpm ladle serve",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/biome-config": "workspace:*",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -24,7 +24,7 @@
     "dev": "pnpm tsc --watch",
     "index": "pnpm zx ../../scripts/indexer.mjs packages/geo",
     "lint": "pnpm biome lint ./",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/typescript-config": "workspace:*",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -24,7 +24,7 @@
     "dev": "pnpm tsc --watch",
     "index": "pnpm zx ../../scripts/indexer.mjs packages/math",
     "lint": "pnpm biome lint ./",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/typescript-config": "workspace:*",

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -24,7 +24,7 @@
     "dev": "pnpm tsc --watch",
     "index": "pnpm zx ../../scripts/indexer.mjs packages/predicates",
     "lint": "pnpm biome lint ./",
-    "test": "pnpm vitest --run --dir src"
+    "test": "pnpm vitest --dir=src"
   },
   "devDependencies": {
     "@accelint/typescript-config": "workspace:*",


### PR DESCRIPTION
remove --run from vitest command because it disables --watch

closes #71 