### PR TITLE
fix: vitest

### DIFF
--- a/.changeset/silver-countries-grab.md
+++ b/.changeset/silver-countries-grab.md
@@ -1,0 +1,5 @@
+---
+"@accelint/vitest-config": patch
+---
+
+Disabled watch mode by default.

--- a/tooling/vitest-config/no-dom.js
+++ b/tooling/vitest-config/no-dom.js
@@ -16,6 +16,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    watch: false,
     coverage: {
       provider: 'istanbul',
       reporter: ['json', 'lcov'],


### PR DESCRIPTION
Disables watch mode by default but still allows you to watch on an individual package level.

Tested `pnpm run test` and `pnpm --filter=@accelint/math run test --watch`