### PR TITLE
refactor: toBoolean does more; narrower predicates

### DIFF
--- a/.changeset/young-kiwis-watch.md
+++ b/.changeset/young-kiwis-watch.md
@@ -1,0 +1,18 @@
+---
+"@accelint/converters": minor
+"@accelint/predicates": minor
+---
+
+The `toBoolean` function (packages/converters) centralizes the logic for coercing a value
+to a boolean which enables the predicate functions (packages/predicates/src/is-noyes) to
+be more specific in what they compare against rather than them simply being alias names
+to broad validation. The available predicates are now:
+
+- `isAnyFalsy`
+- `isAnyTruthy`
+- `isFalse`
+- `isTrue`
+- `isOn`
+- `isOff`
+- `isNo`
+- `isYes`

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@accelint/constants": "workspace:0.1.3",
-    "@accelint/predicates": "workspace:0.1.3",
     "typescript": "^5.6.3"
   },
   "$schema": "https://json.schemastore.org/package",

--- a/packages/converters/src/to-boolean/index.test.ts
+++ b/packages/converters/src/to-boolean/index.test.ts
@@ -13,31 +13,57 @@
 import { expect, it, describe } from 'vitest';
 import { toBoolean } from './';
 
-const truthy = [1, '1', 'on', 'true', 'yes', true, 'ON', 'YES', 'TRUE'];
-const falsey = [
+// biome-ignore lint/style/useNumberNamespace: testing value
+const INFINITY = Infinity;
+
+const falsy = [
+  '',
   0,
+  0.0,
   '0',
-  'off',
-  'false',
-  'no',
+  '0.000',
+  '0000.000',
   false,
+  'false',
+  '  FaLsE ',
+  void 0,
+  Number.NaN,
+  null,
+  undefined,
+];
+const truthy = [
   [],
+  1,
+  '1',
+  true,
+  'true',
   {},
-  'OFF',
-  'NO',
-  'FALSE',
+  'any non-empty string',
+  // 'Yes',
+  // 'yes',
+  // 'No',
+  // 'no',
+  // 'off',
+  // 'Off',
+  // 'OFF',
+  // 'On',
+  // 'on',
+  INFINITY,
+  -INFINITY,
+  Number.POSITIVE_INFINITY,
+  Number.NEGATIVE_INFINITY,
+  /abc/,
+  new Date(),
+  new Error('Fun times.'),
+  () => void 0,
 ];
 
 describe('toBoolean', () => {
-  for (const item of truthy) {
-    it(`should return true for ${item}`, () => {
-      expect(toBoolean(item)).toBeTruthy();
-    });
-  }
+  it.each(falsy)('%s', (val) => {
+    expect(toBoolean(val)).toBe(false);
+  });
 
-  for (const item of falsey) {
-    it(`should return false for ${item}`, () => {
-      expect(toBoolean(item)).not.toBeTruthy();
-    });
-  }
+  it.each(truthy)('%s', (val) => {
+    expect(toBoolean(val)).toBe(true);
+  });
 });

--- a/packages/converters/src/to-boolean/index.ts
+++ b/packages/converters/src/to-boolean/index.ts
@@ -10,30 +10,29 @@
  * governing permissions and limitations under the License.
  */
 
-import { isTrue } from '@accelint/predicates';
-
 /**
- * Compare the given value against a custom list of `truthy` values.
+ * Returns true for any value not found to be a "false" value.
  *
- * String values are not case sensitive.
+ * **"false" values**
+ *   - inherently false values: '' (empty string), 0, false, undefined, null, NaN
+ *   - numeric zero: '0.000' - any number of leading or trailing zeros
+ *   - string literal: 'false' - any capitalizations or space-padding
  *
- * _1, '1', 'on', 'true', 'yes', true_
+ * For more restrictive comparisons against: true, false, on, off, yes, no; see
+ * the predicates package (\@accelint/predicates).
  *
  * @pure
  *
  * @example
- * toBoolean('on');
- * // true
- *
- * toBoolean('yes');
- * // true
- *
- * toBoolean('off');
- * // false
- *
- * toBoolean('no');
- * // false
+ * toBoolean(1);          // true
+ * toBoolean(' FaLsE ');  // false
+ * toBoolean('  true');   // true
+ * toBoolean('000.000');  // false
  */
 export function toBoolean(val: unknown) {
-  return isTrue(val);
+  return !(
+    !val ||
+    `${val}`.trim().toLowerCase() === 'false' ||
+    Number.parseFloat(`${val}`) === 0
+  );
 }

--- a/packages/predicates/src/index.ts
+++ b/packages/predicates/src/index.ts
@@ -6,7 +6,16 @@ export { isBbox } from './is-bbox';
 export { isLatitude } from './is-latitude';
 export { isLongitude } from './is-longitude';
 export { isNothing } from './is-nothing';
-export { isFalse, isNo, isOff, isOn, isTrue, isYes } from './is-noyes';
+export {
+  isAnyFalsy,
+  isAnyTruthy,
+  isFalse,
+  isNo,
+  isOff,
+  isOn,
+  isTrue,
+  isYes,
+} from './is-noyes';
 export {
   isFiniteNumber,
   isFiniteNumeric,

--- a/packages/predicates/src/is-noyes/index.ts
+++ b/packages/predicates/src/is-noyes/index.ts
@@ -10,154 +10,190 @@
  * governing permissions and limitations under the License.
  */
 
-// const trueRegex = /^(?:y|yes|true|1|on)$/i;
-// const falseRegex = /^(?:n|no|false|0|off)$/i;
+// NOTE: There is some conceptual overlap between these (predicates) functions, and the
+// toBoolean (converters) function. The purposes of these two packages differ in intent:
+// - the converter is only narrowly concerned with converting to a boolean
+// - these functions will allow for a broader range of values to evaluate to boolean
 
-// const test = (r: RegExp, val: unknown) => r.test(`${val}`.trim());
+const listFalse = ['', '0', 'false', 'nan', 'null', 'undefined'];
+const listTrue = ['1', 'true'];
 
-const falseValues = ['0', 'false', 'n', 'no', 'off'];
-const trueValues = ['1', 'true', 'y', 'yes', 'on'];
+const listNo = ['n', 'no', ...listFalse];
+const listOff = ['off', ...listFalse];
+const listOn = ['on', ...listTrue];
+const listYes = ['y', 'yes', ...listTrue];
 
 const test = (list: string[], val: unknown) =>
   list.includes(`${val}`.trim().toLowerCase());
 
 /**
- * Compare the given value against a custom list of `falsey` values.
- *
- * String values are not case sensitive.
- *
- * _0, '0', 'n', 'no', 'off', 'false', false_
+ * Returns true if the given value is found in any of:
+ * - `isFalse(val)`
+ * - `isNo(val)`
+ * - `isOff(val)`
  *
  * @pure
  *
  * @example
- * isFalse('on');
- * // false
- *
- * isFalse('yes');
- * // false
- *
- * isFalse('off');
- * // true
- *
- * isFalse('no');
+ * isAnyFalsy('');        // true
+ * isAnyFalsy('no');      // true
+ * isAnyFalsy('off');     // true
+ * isAnyFalsy(0);         // true
+ * isAnyFalsy(1);         // false
+ * isAnyFalsy(true);      // false
+ * isAnyFalsy('on');      // false
+ * isAnyFalsy('yes');     // false
  */
-export const isFalse = (val: unknown) => test(falseValues, val);
+export const isAnyFalsy = (val: unknown) =>
+  isFalse(val) || isNo(val) || isOff(val);
 
 /**
- * Compare the given value against a custom list of `falsey` values.
- *
- * String values are not case sensitive.
- *
- * _0, '0', 'n', 'no', 'off', 'false', false_
+ * Returns true if the given value is found in any of:
+ * - `isTrue(val)`
+ * - `isYes(val)`
+ * - `isOn(val)`
  *
  * @pure
  *
  * @example
- * isNo('on');
- * // false
- *
- * isNo('yes');
- * // false
- *
- * isNo('off');
- * // true
- *
- * isNo('no');
+ * isAnyTruthy('');        // false
+ * isAnyTruthy('no');      // false
+ * isAnyTruthy('off');     // false
+ * isAnyTruthy(0);         // false
+ * isAnyTruthy(1);         // true
+ * isAnyTruthy(true);      // true
+ * isAnyTruthy('on');      // true
+ * isAnyTruthy('yes');     // true
  */
-export const isNo = isFalse;
+export const isAnyTruthy = (val: unknown) =>
+  isTrue(val) || isYes(val) || isOn(val);
 
 /**
- * Compare the given value against a custom list of `falsey` values.
+ * Returns true if the given value is found in a case-insensitive list of
+ * "false" values.
  *
- * String values are not case sensitive.
+ * False values: ['', '0', 'false', 'nan', 'null', 'undefined']
  *
- * _0, '0', 'n', 'no', 'off', 'false', false_
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
  *
  * @pure
  *
  * @example
- * isOff('on');
- * // false
- *
- * isOff('yes');
- * // false
- *
- * isOff('off');
- * // true
- *
- * isOff('no');
+ * isFalse('');        // true
+ * isFalse(0);         // true
+ * isFalse(1);         // false
+ * isFalse(true);      // false
  */
-export const isOff = isFalse;
+export const isFalse = (val: unknown) => test(listFalse, val);
 
 /**
- * Compare the given value against a custom list of `truthy` values.
+ * Returns true if the given value is found in a case-insensitive list of
+ * "no" values.
  *
- * String values are not case sensitive.
+ * False values: ['', '0', 'false', 'nan', 'null', 'undefined']
  *
- * _1, '1', 'y', 'yes', 'on', 'true', true_
+ * Additional values: ['n', 'no']
+ *
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
  *
  * @pure
  *
  * @example
- * isTrue('on');
- * // true
- *
- * isTrue('yes');
- * // true
- *
- * isTrue('off');
- * // false
- *
- * isTrue('no');
- * // false
+ * isNo('n');       // true
+ * isNo('');        // true
+ * isNo(0);         // true
+ * isNo(1);         // false
+ * isNo(true);      // false
+ * isNo('yes');     // false
  */
-export const isTrue = (val: unknown) => test(trueValues, val);
+export const isNo = (val: unknown) => test(listNo, val);
 
 /**
- * Compare the given value against a custom list of `truthy` values.
+ * Returns true if the given value is found in a case-insensitive list of
+ * "off" values.
  *
- * String values are not case sensitive.
+ * False values: ['', '0', 'false', 'nan', 'null', 'undefined']
  *
- * _1, '1', 'y', 'yes', 'on', 'true', true_
+ * Additional values: ['off']
+ *
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
  *
  * @pure
  *
  * @example
- * isOn('on');
- * // true
- *
- * isOn('yes');
- * // true
- *
- * isOn('off');
- * // false
- *
- * isOn('no');
- * // false
+ * isOff('off');     // true
+ * isOff('');        // true
+ * isOff(0);         // true
+ * isOff(1);         // false
+ * isOff(true);      // false
+ * isOff('on');      // false
  */
-export const isOn = isTrue;
+export const isOff = (val: unknown) => test(listOff, val);
 
 /**
- * Compare the given value against a custom list of `truthy` values.
+ * Returns true if the given value is found in a case-insensitive list of
+ * "on" values.
  *
- * String values are not case sensitive.
+ * True values: ['1', 'true']
  *
- * _1, '1', 'y', 'yes', 'on', 'true', true_
+ * Additional values: ['on']
+ *
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
  *
  * @pure
  *
  * @example
- * isYes('on');
- * // true
- *
- * isYes('yes');
- * // true
- *
- * isYes('off');
- * // false
- *
- * isYes('no');
- * // false
+ * isOn('off');     // false
+ * isOn('');        // false
+ * isOn(0);         // false
+ * isOn(1);         // true
+ * isOn(true);      // true
+ * isOn('on');      // true
  */
-export const isYes = isTrue;
+export const isOn = (val: unknown) => test(listOn, val);
+
+/**
+ * Returns true if the given value is found in a case-insensitive list of
+ * "true" values.
+ *
+ * True values: ['1', 'true']
+ *
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
+ *
+ * @pure
+ *
+ * @example
+ * isOn('no');      // false
+ * isOn('');        // false
+ * isOn(0);         // false
+ * isOn(1);         // true
+ * isOn(true);      // true
+ * isOn('yes');     // true
+ */
+export const isTrue = (val: unknown) => test(listTrue, val);
+
+/**
+ * Returns true if the given value is found in a case-insensitive list of
+ * "yes" values.
+ *
+ * True values: ['1', 'true']
+ *
+ * Additional values: ['y', 'yes']
+ *
+ * For a more liberal comparison/coercion to true or false see the converters
+ * package (\@accelint/converters).
+ *
+ * @pure
+ *
+ * @example
+ * isTrue('');        // false
+ * isTrue(0);         // false
+ * isTrue(1);         // true
+ * isTrue(true);      // true
+ */
+export const isYes = (val: unknown) => test(listYes, val);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,6 @@ importers:
       '@accelint/constants':
         specifier: workspace:0.1.3
         version: link:../constants
-      '@accelint/predicates':
-        specifier: workspace:0.1.3
-        version: link:../predicates
       typescript:
         specifier: ^5.6.3
         version: 5.6.3


### PR DESCRIPTION
the toBoolean function centralizes the logic for coercing a value and allows the predicate functions to be more specific in what they validate rather than them simply being alais names to broad validation.

Closes #122

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The function `toBoolean` no longer will consider specific values - 'no', 'off', 'n' to be "false" or 'on', 'yes', 'y' to be "true". If that is being relied on that assumption will break; no tests show this to be extant.

## 💬 Other information

