### PR TITLE
chore(docs): use typedoc directly

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -30,3 +30,4 @@ ignore:
   - '**/dist'
   - '**/documentation'
   - '**/node_modules'
+  - 'apps/docs/src/public'

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -25,7 +25,6 @@ ignore:
   - '**/.turbo'
   - '**/__fixtures__'
   - '**/__snapshots__'
-  - '**/apps/docs/**/typedocs-output'
   - '**/build'
   - '**/coverage'
   - '**/dist'

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -6,6 +6,8 @@
 # Dist
 node_modules
 dist/
+typedoc/
+ladle/
 
 # IDE
 .vscode/*

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -6,7 +6,6 @@
 # Dist
 node_modules
 dist/
-src/typedocs-output
 
 # IDE
 .vscode/*

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -6,8 +6,9 @@
 # Dist
 node_modules
 dist/
-typedoc/
-ladle/
+
+# generated files
+src/public/
 
 # IDE
 .vscode/*

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "pnpm run build:deps && rspress dev",
     "build:deps": "pnpm run build:ladle && pnpm run build:typedoc",
-    "build:ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/ladle --base ladle",
+    "build:ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/src/public/ladle --base ladle",
     "build:typedoc": "typedoc",
     "build": "pnpm run build:deps && rspress build",
     "preview": "rspress preview",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,6 +13,7 @@
     "preview": "rspress preview"
   },
   "dependencies": {
+    "@accelint/design-system": "workspace:*",
     "@rspress/plugin-playground": "^1.38.0",
     "@types/node": "^18.19.67",
     "react": "^18.3.1",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,18 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "rspress build && pnpm run build-ladle",
-    "build-ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/dist/ladle --base ladle",
+    "dev": "pnpm run build:deps && rspress dev",
+    "build:deps": "pnpm run build:ladle && pnpm run build:typedoc",
+    "build:ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/ladle --base ladle",
+    "build:typedoc": "typedoc",
+    "build": "pnpm run build:deps && rspress build",
+    "preview": "rspress preview",
     "check": "biome check --write",
-    "dev": "rspress dev",
-    "format": "biome format --write",
-    "preview": "rspress preview"
+    "format": "biome format --write"
   },
   "dependencies": {
     "@rspress/plugin-playground": "^1.38.0",
     "@types/node": "^18.19.67",
     "react": "^18.3.1",
     "rspress": "^1.37.3",
+    "typedoc": "0.27.6",
+    "typedoc-plugin-markdown": "4.3.3",
     "typescript": "^5.7.2"
   },
   "devDependencies": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm run build:deps && rspress dev",
     "build:deps": "pnpm run build:ladle && pnpm run build:typedoc",
     "build:ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/src/public/ladle --base ladle",
     "build:typedoc": "typedoc",
     "build": "pnpm run build:deps && rspress build",
-    "preview": "rspress preview",
     "check": "biome check --write",
-    "format": "biome format --write"
+    "dev": "pnpm run build:deps && rspress dev",
+    "format": "biome format --write",
+    "preview": "rspress preview"
   },
   "dependencies": {
     "@rspress/plugin-playground": "^1.38.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@rspress/plugin-playground": "^1.38.0",
-    "@rspress/plugin-typedoc": "^1.38.0",
     "@types/node": "^18.19.67",
     "react": "^18.3.1",
     "rspress": "^1.37.3",

--- a/apps/docs/rspress.config.ts
+++ b/apps/docs/rspress.config.ts
@@ -1,13 +1,9 @@
 import * as path from 'node:path';
 
 import { pluginPlayground } from '@rspress/plugin-playground';
-import { pluginTypeDoc } from '@rspress/plugin-typedoc';
 import { defineConfig } from 'rspress/config';
 
 // import customInstallBlock from './lib/plugin-remark-custom-install.ts';
-
-const module = (...parts: string[]) =>
-  path.join(__dirname, '..', '..', 'packages', ...parts);
 
 export default defineConfig({
   markdown: {
@@ -26,15 +22,6 @@ export default defineConfig({
     pluginPlayground({
       defaultDirection: 'vertical',
       defaultRenderMode: 'pure', // or 'playground'
-    }),
-    pluginTypeDoc({
-      entryPoints: [
-        // TODO: auto-generate these entries
-        module('converters', 'src', 'to-boolean', 'index.ts'),
-      ],
-      // NOTE: haven't gotten this working yet; the output of typedoc outside of the src/ dir
-      // outDir: '../typedoc',
-      outDir: 'typedocs-output',
     }),
   ],
   outDir: path.join(__dirname, 'dist'),

--- a/apps/docs/src/packages/converters/to-boolean.mdx
+++ b/apps/docs/src/packages/converters/to-boolean.mdx
@@ -1,5 +1,5 @@
 import Install from '/lib/install';
-import Typedoc from "/src/typedocs-output/functions/toBoolean.md";
+// import Typedoc from "/src/typedocs-output/functions/toBoolean.md";
 
 # toBoolean
 
@@ -13,4 +13,4 @@ toBoolean('1'); // < returns true
 toBoolean(0); // < returns false
 ```
 
-<Typedoc />
+{/* <Typedoc /> */}

--- a/apps/docs/src/packages/converters/to-boolean.mdx
+++ b/apps/docs/src/packages/converters/to-boolean.mdx
@@ -1,5 +1,5 @@
 import Install from '/lib/install';
-import Typedoc from "/typedoc/@accelint/converters/functions/toBoolean.md";
+import Typedoc from "/src/public/typedoc/@accelint/converters/functions/toBoolean.md";
 
 # toBoolean
 

--- a/apps/docs/src/packages/converters/to-boolean.mdx
+++ b/apps/docs/src/packages/converters/to-boolean.mdx
@@ -1,5 +1,5 @@
 import Install from '/lib/install';
-// import Typedoc from "/src/typedocs-output/functions/toBoolean.md";
+import Typedoc from "/typedoc/@accelint/converters/functions/toBoolean.md";
 
 # toBoolean
 
@@ -13,4 +13,4 @@ toBoolean('1'); // < returns true
 toBoolean(0); // < returns false
 ```
 
-{/* <Typedoc /> */}
+<Typedoc />

--- a/apps/docs/typedoc.config.mjs
+++ b/apps/docs/typedoc.config.mjs
@@ -6,7 +6,7 @@ const config = {
   packageOptions: {
     entryPoints: ['src/index.ts'],
   },
-  out: 'typedoc',
+  out: 'src/public/typedoc',
 
   // properties taken from plugin-typedoc https://github.com/web-infra-dev/rspress/blob/main/packages/plugin-typedoc/src/index.ts#L40-L53
   theme: 'markdown',

--- a/apps/docs/typedoc.config.mjs
+++ b/apps/docs/typedoc.config.mjs
@@ -1,0 +1,20 @@
+/** @type {Partial<import("typedoc").TypeDocOptions>} */
+const config = {
+  plugin: ['typedoc-plugin-markdown'],
+  entryPointStrategy: 'packages',
+  entryPoints: ['../../packages/*'],
+  packageOptions: {
+    entryPoints: ['src/index.ts'],
+  },
+  out: 'typedoc',
+
+  // properties taken from plugin-typedoc https://github.com/web-infra-dev/rspress/blob/main/packages/plugin-typedoc/src/index.ts#L40-L53
+  theme: 'markdown',
+  disableSources: true,
+  readme: 'none',
+  githubPages: false,
+  requiredToBeDocumented: ['Class', 'Function', 'Interface'],
+  hideBreadcrumbs: true,
+};
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@rspress/plugin-playground':
         specifier: ^1.38.0
         version: 1.39.2(@rspress/core@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@rspress/plugin-typedoc':
-        specifier: ^1.38.0
-        version: 1.39.2(rspress@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(typescript@5.7.2)
       '@types/node':
         specifier: ^18.19.67
         version: 18.19.68
@@ -2550,12 +2547,6 @@ packages:
       react: '>=17.0.0'
       react-router-dom: ^6.8.1
 
-  '@rspress/plugin-typedoc@1.39.2':
-    resolution: {integrity: sha512-HZYfeD+QlWbTDydiZnFMiDWlFGKWVSPGID5LIjQ2jjFiH2H1EHYjfSPPLrVCI2zOVj2E+PGPebSN+TKfpPlOYA==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      rspress: ^1.39.2
-
   '@rspress/runtime@1.39.2':
     resolution: {integrity: sha512-T4OR+HHFtRvpG3HyBXHG3eGNQM0VefNnrTLdd2hgSecpewkjRYU1uv3TOo1XP5prMwlvG1kApHderJC/LXFx8Q==}
     engines: {node: '>=14.17.6'}
@@ -2995,9 +2986,6 @@ packages:
   ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
-
-  ansi-sequence-parser@1.1.1:
-    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -3819,11 +3807,6 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -4314,9 +4297,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lunr@2.3.9:
-    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4341,11 +4321,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked@4.3.0:
-    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
-    engines: {node: '>= 12'}
-    hasBin: true
 
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
@@ -4696,9 +4671,6 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -5519,9 +5491,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@0.14.7:
-    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -5934,18 +5903,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typedoc-plugin-markdown@3.17.1:
-    resolution: {integrity: sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==}
-    peerDependencies:
-      typedoc: '>=0.24.0'
-
-  typedoc@0.24.8:
-    resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
-    engines: {node: '>= 14.14'}
-    hasBin: true
-    peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
-
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
@@ -5958,11 +5915,6 @@ packages:
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
-
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
 
   unconfig@0.6.0:
     resolution: {integrity: sha512-4C67J0nIF2QwSXty2kW3zZx1pMZ3iXabylvJWWgHybWVUcMf9pxwsngoQt0gC+AVstRywFqrRBp3qOXJayhpOw==}
@@ -6170,12 +6122,6 @@ packages:
       jsdom:
         optional: true
 
-  vscode-oniguruma@1.7.0:
-    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-
-  vscode-textmate@8.0.0:
-    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
-
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6240,9 +6186,6 @@ packages:
   widest-line@4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -8703,15 +8646,6 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@rspress/plugin-typedoc@1.39.2(rspress@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(typescript@5.7.2)':
-    dependencies:
-      '@rspress/shared': 1.39.2
-      rspress: 1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
-      typedoc: 0.24.8(typescript@5.7.2)
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.24.8(typescript@5.7.2))
-    transitivePeerDependencies:
-      - typescript
-
   '@rspress/runtime@1.39.2':
     dependencies:
       '@rspress/shared': 1.39.2
@@ -9354,8 +9288,6 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
-
-  ansi-sequence-parser@1.1.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -10177,15 +10109,6 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  handlebars@4.7.8:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -10809,8 +10732,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lunr@2.3.9: {}
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -10832,8 +10753,6 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
-
-  marked@4.3.0: {}
 
   mdast-util-definitions@5.1.2:
     dependencies:
@@ -11710,8 +11629,6 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
-
-  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -12758,13 +12675,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@0.14.7:
-    dependencies:
-      ansi-sequence-parser: 1.1.1
-      jsonc-parser: 3.3.1
-      vscode-oniguruma: 1.7.0
-      vscode-textmate: 8.0.0
-
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -13179,27 +13089,11 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typedoc-plugin-markdown@3.17.1(typedoc@0.24.8(typescript@5.7.2)):
-    dependencies:
-      handlebars: 4.7.8
-      typedoc: 0.24.8(typescript@5.7.2)
-
-  typedoc@0.24.8(typescript@5.7.2):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.5
-      shiki: 0.14.7
-      typescript: 5.7.2
-
   typescript@5.6.3: {}
 
   typescript@5.7.2: {}
 
   ufo@1.5.4: {}
-
-  uglify-js@3.19.3:
-    optional: true
 
   unconfig@0.6.0:
     dependencies:
@@ -13503,10 +13397,6 @@ snapshots:
       - supports-color
       - terser
 
-  vscode-oniguruma@1.7.0: {}
-
-  vscode-textmate@8.0.0: {}
-
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -13587,8 +13477,6 @@ snapshots:
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
-
-  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
     dependencies:
       '@rspress/plugin-playground':
         specifier: ^1.38.0
-        version: 1.39.2(@rspress/core@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.39.3(@rspress/core@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^18.19.67
         version: 18.19.68
@@ -64,7 +64,13 @@ importers:
         version: 18.3.1
       rspress:
         specifier: ^1.37.3
-        version: 1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+        version: 1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      typedoc:
+        specifier: 0.27.6
+        version: 0.27.6(typescript@5.7.2)
+      typedoc-plugin-markdown:
+        specifier: 4.3.3
+        version: 4.3.3(typedoc@0.27.6(typescript@5.7.2))
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -1297,6 +1303,9 @@ packages:
   '@formatjs/intl-localematcher@0.5.9':
     resolution: {integrity: sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==}
 
+  '@gerrit0/mini-shiki@1.24.4':
+    resolution: {integrity: sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==}
+
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2465,8 +2474,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@1.39.2':
-    resolution: {integrity: sha512-fcI1+kJ0Ch88dU1kgFYc+OJc/Q9Ps+da2aWl+o2dX4M4H59/iIMgvUEqLedomAeNHP1Ee6I+Sb7VaWkMsKKZYA==}
+  '@rspress/core@1.39.3':
+    resolution: {integrity: sha512-xY2DXYEKk6M4rZt2Yx+exUwX1MaJt6WRBirUc+5gv7uSdnxdMgFD9bL7ppR8oevmaIhzvcGLeVi7VBcdqG1Nlg==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.4':
@@ -2521,45 +2530,54 @@ packages:
     resolution: {integrity: sha512-uKAWxA8wY3iKKv+ZSN69iu4wJoa2ZNGOQmbnZskIHPejWa0lbkbbb85SlVhzKnPo04NKG675g6G6rT7REWDieQ==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.39.2':
-    resolution: {integrity: sha512-pNebOMQ5PouYTGKAhWvpUBu4ama7a1ySLs5ZNALp9wRsvQMNY9RPM1rs6Wz0Qj8ey85j/L3HNEr/yTr8wnMvOw==}
+  '@rspress/plugin-auto-nav-sidebar@1.39.3':
+    resolution: {integrity: sha512-Z64FILjUaBKNE7c6mRcSL64S11DLpS84CFVQrAEANx1GkliacWoCZO84mWGDirj5iTsuiS6augMJxIaC2RS5tA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@1.39.2':
-    resolution: {integrity: sha512-bUbuPA9uuTX/SdswnwyIklvjLanlr4Y9lbO9B590rrCptaE99w/ydKyM23FJZ5tZkZp+7W8+RvCWt/5bXq6lNw==}
+  '@rspress/plugin-container-syntax@1.39.3':
+    resolution: {integrity: sha512-wO/Rk6nGesKmZ/b+HIotkMT3HAeR0Z3QdtpT5qj29CseBeY9L1NhtHiEc0nn2nR3kQKndcEIqRFumvnE01ry7Q==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@1.39.2':
-    resolution: {integrity: sha512-+r/L0Wr9XamdbgLcuza/ETWG88REhlzyf4PUmoKOQgvxe4D5dLXToA7/MQoYfueCak1WK1ENX2puNdL428qXmg==}
+  '@rspress/plugin-last-updated@1.39.3':
+    resolution: {integrity: sha512-0kw9sAdOR/9ZppC0ebSSprit6SE5j0ABYtIxQBTkTc56D2WYHJMRIJgXKySImW42koiVbNkZm+OCozqm5BTFbA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@1.39.2':
-    resolution: {integrity: sha512-uPaeAR3bX0DbMn3FvueNV0vpNbr99AbP7c3CF75L+UxM+xelO/VUc7EpM+5QhoT7Mvs1vtMWQRMNfZfMcABDmA==}
+  '@rspress/plugin-medium-zoom@1.39.3':
+    resolution: {integrity: sha512-AIIxQjC0u8wRTWBW3U5FWFG3kWJ1zkJEXbTXMvKBT7HykUhwC+vnUh6l8UCe+HQYwuFaIEasmEwI4UAho0ZhYg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.39.2
+      '@rspress/runtime': ^1.39.3
 
-  '@rspress/plugin-playground@1.39.2':
-    resolution: {integrity: sha512-Bftz6sMvzETVCvFLtgD9BwCfpNvGuHDaczYuiyVqBJIDwIXlsffDCvjTrECf+3/IBLaBwrQMFbuoKsZau9rJ7g==}
+  '@rspress/plugin-playground@1.39.3':
+    resolution: {integrity: sha512-Tgd4aG+aiHpXkFnTl9el9DdJCx0SiIYE7U79fg1wmrQsN86NEY9f/D5WEky9lgEnA+3SHJEsju1BgnnBcFkndw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/core': ^1.39.2
+      '@rspress/core': ^1.39.3
       react: '>=17.0.0'
       react-router-dom: ^6.8.1
 
-  '@rspress/runtime@1.39.2':
-    resolution: {integrity: sha512-T4OR+HHFtRvpG3HyBXHG3eGNQM0VefNnrTLdd2hgSecpewkjRYU1uv3TOo1XP5prMwlvG1kApHderJC/LXFx8Q==}
+  '@rspress/runtime@1.39.3':
+    resolution: {integrity: sha512-iOoAKDST9bFopl+Bwpfg5+5NqKFf9SaPiuKW4EyoNjQBJpvQZh4nrauusz84sXarIg9frhOnpN/M7YTPbEa+EQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.39.2':
-    resolution: {integrity: sha512-4io40wGxerMDYzkkiavw38m/tJQ7FuNCmROqDMOyvCsXB/5TcGTG40kb5YveV2QpB+uiKpmqf/xB7/VJHMe+yA==}
+  '@rspress/shared@1.39.3':
+    resolution: {integrity: sha512-lzOHBJNN4POkSaIWoehXi9iWZvjclLhny+RGP53oTRuOlS6MWORKc3Q2V/ga+2uh2c99DgvPa62dRtqdfazkQQ==}
 
-  '@rspress/theme-default@1.39.2':
-    resolution: {integrity: sha512-ICDjGGok2OWNsyqTNR83BVXdsYAhdUv6prkrKazKypghcpgn6TPSfgpyeUKROimpgoiBC2Cb6S+AxVd24mmh3w==}
+  '@rspress/theme-default@1.39.3':
+    resolution: {integrity: sha512-3eJc/loocaUpAbrgDJY7a9iX+Og8hLkuIkgCwf4orl57oFdldm8xbAZHtNro71tIgi/c/13kdGDZCCygwut/9A==}
     engines: {node: '>=14.17.6'}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@shikijs/engine-oniguruma@1.24.4':
+    resolution: {integrity: sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==}
+
+  '@shikijs/types@1.24.4':
+    resolution: {integrity: sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==}
+
+  '@shikijs/vscode-textmate@9.3.1':
+    resolution: {integrity: sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -4236,6 +4254,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4297,6 +4318,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4318,6 +4342,10 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4420,6 +4448,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-query-parser@2.0.2:
     resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
@@ -4929,8 +4960,8 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
+  pkg-types@1.3.0:
+    resolution: {integrity: sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -5009,6 +5040,10 @@ packages:
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -5282,8 +5317,8 @@ packages:
   rspack-plugin-virtual-module@0.1.13:
     resolution: {integrity: sha512-VC0HiVHH6dtGfTgfpbDgVTt6LlYv+uAg9CWGWAR5lBx9FbKPEZeGz7iRUUP8vMymx+PGI8ps0u4a25dne0rtuQ==}
 
-  rspress@1.39.2:
-    resolution: {integrity: sha512-abGMsqQI71BopHDDSYHBjJ6eWQeJmuf6yzTDeumb6vvBJdc9hKEV5LQifeiptdhP28cqM3tT++o6uhI/3klKMg==}
+  rspress@1.39.3:
+    resolution: {integrity: sha512-XNsgPIdkVenP4knrys8WSN87nuTe32in2zg4+i9UbPUduOA9n082pwMpnxL5FIraUe3ZjSI2nzwEBRlkmPY72Q==}
     hasBin: true
 
   run-applescript@7.0.0:
@@ -5903,6 +5938,19 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  typedoc-plugin-markdown@4.3.3:
+    resolution: {integrity: sha512-kESCcNRzOcFJATLML2FoCfaTF9c0ujmbZ+UXsJvmNlFLS3v8tDKfDifreJXvXWa9d8gUcetZqOqFcZ/7+Ba34Q==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.27.x
+
+  typedoc@0.27.6:
+    resolution: {integrity: sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
+
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
@@ -5912,6 +5960,9 @@ packages:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -6853,6 +6904,12 @@ snapshots:
   '@formatjs/intl-localematcher@0.5.9':
     dependencies:
       tslib: 2.8.1
+
+  '@gerrit0/mini-shiki@1.24.4':
+    dependencies:
+      '@shikijs/engine-oniguruma': 1.24.4
+      '@shikijs/types': 1.24.4
+      '@shikijs/vscode-textmate': 9.3.1
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -8537,7 +8594,7 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.16.0
 
-  '@rspress/core@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
+  '@rspress/core@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@mdx-js/mdx': 2.3.0
@@ -8547,13 +8604,13 @@ snapshots:
       '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.13)
       '@rsbuild/plugin-sass': 1.1.2(@rsbuild/core@1.1.13)
       '@rspress/mdx-rs': 0.6.4
-      '@rspress/plugin-auto-nav-sidebar': 1.39.2
-      '@rspress/plugin-container-syntax': 1.39.2
-      '@rspress/plugin-last-updated': 1.39.2
-      '@rspress/plugin-medium-zoom': 1.39.2(@rspress/runtime@1.39.2)
-      '@rspress/runtime': 1.39.2
-      '@rspress/shared': 1.39.2
-      '@rspress/theme-default': 1.39.2
+      '@rspress/plugin-auto-nav-sidebar': 1.39.3
+      '@rspress/plugin-container-syntax': 1.39.3
+      '@rspress/plugin-last-updated': 1.39.3
+      '@rspress/plugin-medium-zoom': 1.39.3(@rspress/runtime@1.39.3)
+      '@rspress/runtime': 1.39.3
+      '@rspress/shared': 1.39.3
+      '@rspress/theme-default': 1.39.3
       enhanced-resolve: 5.18.0
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8613,30 +8670,30 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.4
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.4
 
-  '@rspress/plugin-auto-nav-sidebar@1.39.2':
+  '@rspress/plugin-auto-nav-sidebar@1.39.3':
     dependencies:
-      '@rspress/shared': 1.39.2
+      '@rspress/shared': 1.39.3
 
-  '@rspress/plugin-container-syntax@1.39.2':
+  '@rspress/plugin-container-syntax@1.39.3':
     dependencies:
-      '@rspress/shared': 1.39.2
+      '@rspress/shared': 1.39.3
 
-  '@rspress/plugin-last-updated@1.39.2':
+  '@rspress/plugin-last-updated@1.39.3':
     dependencies:
-      '@rspress/shared': 1.39.2
+      '@rspress/shared': 1.39.3
 
-  '@rspress/plugin-medium-zoom@1.39.2(@rspress/runtime@1.39.2)':
+  '@rspress/plugin-medium-zoom@1.39.3(@rspress/runtime@1.39.3)':
     dependencies:
-      '@rspress/runtime': 1.39.2
+      '@rspress/runtime': 1.39.3
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-playground@1.39.2(@rspress/core@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@rspress/plugin-playground@1.39.3(@rspress/core@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 2.3.0
       '@monaco-editor/react': 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@oxidation-compiler/napi': 0.2.0
-      '@rspress/core': 1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
-      '@rspress/shared': 1.39.2
+      '@rspress/core': 1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      '@rspress/shared': 1.39.3
       react: 18.3.1
       react-router-dom: 6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       remark-gfm: 3.0.1
@@ -8646,15 +8703,15 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@rspress/runtime@1.39.2':
+  '@rspress/runtime@1.39.3':
     dependencies:
-      '@rspress/shared': 1.39.2
+      '@rspress/shared': 1.39.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@rspress/shared@1.39.2':
+  '@rspress/shared@1.39.3':
     dependencies:
       '@rsbuild/core': 1.1.13
       chalk: 5.4.1
@@ -8664,11 +8721,11 @@ snapshots:
       lodash-es: 4.17.21
       unified: 10.1.2
 
-  '@rspress/theme-default@1.39.2':
+  '@rspress/theme-default@1.39.3':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.39.2
-      '@rspress/shared': 1.39.2
+      '@rspress/runtime': 1.39.3
+      '@rspress/shared': 1.39.3
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -8685,6 +8742,18 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@shikijs/engine-oniguruma@1.24.4':
+    dependencies:
+      '@shikijs/types': 1.24.4
+      '@shikijs/vscode-textmate': 9.3.1
+
+  '@shikijs/types@1.24.4':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.1
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@9.3.1': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -10675,6 +10744,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.0: {}
@@ -10732,6 +10805,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -10751,6 +10826,15 @@ snapshots:
   markdown-extensions@1.1.1: {}
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -11068,6 +11152,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.0.0: {}
 
   media-query-parser@2.0.2:
     dependencies:
@@ -11638,7 +11724,7 @@ snapshots:
     dependencies:
       acorn: 8.14.0
       pathe: 1.1.2
-      pkg-types: 1.2.1
+      pkg-types: 1.3.0
       ufo: 1.5.4
 
   modern-ahocorasick@1.1.0: {}
@@ -11917,7 +12003,7 @@ snapshots:
 
   pirates@4.0.6: {}
 
-  pkg-types@1.2.1:
+  pkg-types@1.3.0:
     dependencies:
       confbox: 0.1.8
       mlly: 1.7.3
@@ -12003,6 +12089,8 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -12472,11 +12560,11 @@ snapshots:
     dependencies:
       fs-extra: 11.2.0
 
-  rspress@1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)):
+  rspress@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@rsbuild/core': 1.1.13
-      '@rspress/core': 1.39.2(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
-      '@rspress/shared': 1.39.2
+      '@rspress/core': 1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      '@rspress/shared': 1.39.3
       cac: 6.7.14
       chalk: 5.4.1
       chokidar: 3.6.0
@@ -13089,9 +13177,24 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  typedoc-plugin-markdown@4.3.3(typedoc@0.27.6(typescript@5.7.2)):
+    dependencies:
+      typedoc: 0.27.6(typescript@5.7.2)
+
+  typedoc@0.27.6(typescript@5.7.2):
+    dependencies:
+      '@gerrit0/mini-shiki': 1.24.4
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.7.2
+      yaml: 2.6.1
+
   typescript@5.6.3: {}
 
   typescript@5.7.2: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.5.4: {}
 
@@ -13510,8 +13613,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.6.1:
-    optional: true
+  yaml@2.6.1: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@accelint/design-system':
+        specifier: workspace:*
+        version: link:../../packages/design-system
       '@rspress/plugin-playground':
         specifier: ^1.38.0
         version: 1.39.3(@rspress/core@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## some notes

- putting the generated assets from ladle and typedoc in /docs/src/public was the simplest way i could find to get everything to work in both dev mode and after building. stuff in that dir is just copied to dist [reference](https://rspress.dev/guide/basic/static-assets#other-static-assets)
- right now ladle build and typedoc run before both rspress dev/rspress build. it takes a while, which is kind of annoying. we can likely optimize this if it's prohibitive to development of the docs.

## testing
- do a fresh dep install

DEV
- pnpm --filter=@accelint/docs dev
- verify that the toBoolean doc looks correct
- verify the design-system component story embed works

BUILD/PREVIEW
- pnpm --filter=@accelint/docs build
- pnpm --filter=@accelint/docs preview
- verify that the toBoolean doc looks correct
- verify the design-system component story embed works


![Screenshot 2024-12-27 at 3 55 44 PM](https://github.com/user-attachments/assets/e6b78edb-74ff-4b21-9015-4a177de65ccc)


