### PR TITLE
chore: license script should only try to add license to supported files

### DIFF
--- a/scripts/license.mjs
+++ b/scripts/license.mjs
@@ -39,7 +39,9 @@ const HTML_COMMENT_STYLE = {
 const COMMENT_STYLES = {
   '.js': JS_COMMENT_STYLE,
   '.ts': JS_COMMENT_STYLE,
+  '.mts': JS_COMMENT_STYLE,
   '.tsx': JS_COMMENT_STYLE,
+  '.jsx': JS_COMMENT_STYLE,
   '.mjs': JS_COMMENT_STYLE,
   '.css': JS_COMMENT_STYLE,
   '.md': HTML_COMMENT_STYLE,


### PR DESCRIPTION
follow up to https://github.com/gohypergiant/standard-toolkit/pull/136
it causes some errors when changes are made to files that are not supported by the license generation script.

This PR modifies the script to check if the file type is supported for each file before attempting to add the license

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.

## 📝 Test Instructions:

- the following file types get the license added: `js, ts, tsx, mjs, mdx, md, css`. All other file types should be ignored by the license script
- make a change to a file that is not in the list of file types above (e.g. a package.json)
- commit
- it should commit with no issues

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

