### PR TITLE
chore: hide header in typedoc output files

### DIFF
--- a/apps/docs/typedoc.config.mjs
+++ b/apps/docs/typedoc.config.mjs
@@ -15,6 +15,7 @@ const config = {
   githubPages: false,
   requiredToBeDocumented: ['Class', 'Function', 'Interface'],
   hideBreadcrumbs: true,
+  hidePageHeader: true,
 };
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.39.3(@rspress/core@1.39.3(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2)))(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^18.19.67
-        version: 18.19.68
+        version: 18.19.69
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -132,7 +132,7 @@ importers:
         version: 14.5.2(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: '20'
-        version: 20.17.10
+        version: 20.17.11
       '@types/react':
         specifier: 18.3.11
         version: 18.3.11
@@ -141,13 +141,13 @@ importers:
         version: 18.3.1
       '@vanilla-extract/next-plugin':
         specifier: 2.4.6
-        version: 2.4.6(@types/node@20.17.10)(next@15.0.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+        version: 2.4.6(@types/node@20.17.11)(next@15.0.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@vanilla-extract/vite-plugin':
         specifier: 4.0.16
-        version: 4.0.16(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 4.0.16(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       jsdom:
         specifier: 25.0.1
         version: 25.0.1
@@ -159,10 +159,10 @@ importers:
         version: 5.6.3
       vite:
         specifier: 5.4.9
-        version: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/constants:
     dependencies:
@@ -178,16 +178,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/converters:
     dependencies:
@@ -206,16 +206,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/core:
     dependencies:
@@ -231,16 +231,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/design-system:
     dependencies:
@@ -334,7 +334,7 @@ importers:
         version: 5.1.0
       '@ladle/react':
         specifier: 4.1.2
-        version: 4.1.2(@swc/helpers@0.5.15)(@types/node@20.17.10)(@types/react@18.3.11)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.83.0)(terser@5.37.0)(typescript@5.6.3)
+        version: 4.1.2(@swc/helpers@0.5.15)(@types/node@20.17.11)(@types/react@18.3.11)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.83.0)(terser@5.37.0)(typescript@5.6.3)
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
@@ -358,13 +358,13 @@ importers:
         version: 18.3.1
       '@vanilla-extract/esbuild-plugin':
         specifier: 2.3.11
-        version: 2.3.11(@types/node@20.17.10)(esbuild@0.24.2)(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.3.11(@types/node@20.17.11)(esbuild@0.24.2)(sass-embedded@1.83.0)(terser@5.37.0)
       '@vanilla-extract/vite-plugin':
         specifier: 4.0.16
-        version: 4.0.16(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 4.0.16(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -385,13 +385,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vite:
         specifier: 5.4.9
-        version: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/formatters:
     dependencies:
@@ -407,16 +407,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/geo:
     dependencies:
@@ -444,16 +444,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/math:
     dependencies:
@@ -469,16 +469,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/predicates:
     dependencies:
@@ -497,19 +497,19 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/web-worker':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/temporal:
     dependencies:
@@ -525,16 +525,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/web-worker:
     dependencies:
@@ -553,16 +553,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   packages/websocket:
     dependencies:
@@ -578,16 +578,16 @@ importers:
         version: link:../../tooling/vitest-config
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))
       esbuild-plugin-file-path-extensions:
         specifier: 2.1.3
         version: 2.1.3
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
+        version: 8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
 
   tooling/biome-config: {}
 
@@ -601,16 +601,16 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 4.3.2
-        version: 4.3.2(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 4.3.2(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/coverage-istanbul':
         specifier: 2.1.3
-        version: 2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0))
       vite-tsconfig-paths:
         specifier: 5.0.1
-        version: 5.0.1(typescript@5.7.2)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+        version: 5.0.1(typescript@5.7.2)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0)
+        version: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0)
 
 packages:
 
@@ -1291,23 +1291,23 @@ packages:
   '@fontsource/roboto-mono@5.1.0':
     resolution: {integrity: sha512-7lIxTeanF2XrwAIukUrOUvO9veGkQiG7L7vizMxVjl+lrTwS4GAYyOvziyGZ6/3kU80K3lGd/FnWrmoTud0V6A==}
 
-  '@formatjs/ecma402-abstract@2.3.1':
-    resolution: {integrity: sha512-Ip9uV+/MpLXWRk03U/GzeJMuPeOXpJBSB5V1tjA6kJhvqssye5J5LoYLc7Z5IAHb7nR62sRoguzrFiVCP/hnzw==}
+  '@formatjs/ecma402-abstract@2.3.2':
+    resolution: {integrity: sha512-6sE5nyvDloULiyOMbOTJEEgWL32w+VHkZQs8S02Lnn8Y/O5aQhjOEXwWzvR7SsBE/exxlSpY2EsWZgqHbtLatg==}
 
-  '@formatjs/fast-memoize@2.2.5':
-    resolution: {integrity: sha512-6PoewUMrrcqxSoBXAOJDiW1m+AmkrAj0RiXnOMD59GRaswjXhm3MDhgepXPBgonc09oSirAJTsAggzAGQf6A6g==}
+  '@formatjs/fast-memoize@2.2.6':
+    resolution: {integrity: sha512-luIXeE2LJbQnnzotY1f2U2m7xuQNj2DA8Vq4ce1BY9ebRZaoPB1+8eZ6nXpLzsxuW5spQxr7LdCg+CApZwkqkw==}
 
-  '@formatjs/icu-messageformat-parser@2.9.7':
-    resolution: {integrity: sha512-cuEHyRM5VqLQobANOjtjlgU7+qmk9Q3fDQuBiRRJ3+Wp3ZoZhpUPtUfuimZXsir6SaI2TaAJ+SLo9vLnV5QcbA==}
+  '@formatjs/icu-messageformat-parser@2.9.8':
+    resolution: {integrity: sha512-hZlLNI3+Lev8IAXuwehLoN7QTKqbx3XXwFW1jh0AdIA9XJdzn9Uzr+2LLBspPm/PX0+NLIfykj/8IKxQqHUcUQ==}
 
-  '@formatjs/icu-skeleton-parser@1.8.11':
-    resolution: {integrity: sha512-8LlHHE/yL/zVJZHAX3pbKaCjZKmBIO6aJY1mkVh4RMSEu/2WRZ4Ysvv3kKXJ9M8RJLBHdnk1/dUQFdod1Dt7Dw==}
+  '@formatjs/icu-skeleton-parser@1.8.12':
+    resolution: {integrity: sha512-QRAY2jC1BomFQHYDMcZtClqHR55EEnB96V7Xbk/UiBodsuFc5kujybzt87+qj1KqmJozFhk6n4KiT1HKwAkcfg==}
 
-  '@formatjs/intl-localematcher@0.5.9':
-    resolution: {integrity: sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==}
+  '@formatjs/intl-localematcher@0.5.10':
+    resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
 
-  '@gerrit0/mini-shiki@1.24.4':
-    resolution: {integrity: sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==}
+  '@gerrit0/mini-shiki@1.25.1':
+    resolution: {integrity: sha512-BQ3iwLtmacJpW59cB0TM4ATGMLIz+Ps+9MUxrd7ds4MtYzzPvT6WLYpabYIqEP190hU0Olb8guXZmVp9o58ntw==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -1491,6 +1491,7 @@ packages:
 
   '@ls-lint/ls-lint@2.3.0-beta.1':
     resolution: {integrity: sha512-NmujBNFslP4GhFsB92zh1evSSBadcg+RMsQ5FM70OrU36C3AbQYaVXDn4reC28GM6DFoOtiETRdKV6ie1TfP7g==}
+    cpu: [x64, arm64, s390x, ppc64le]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -1546,8 +1547,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@mswjs/interceptors@0.37.3':
-    resolution: {integrity: sha512-USvgCL/uOGFtVa6SVyRrC8kIAedzRohxIXN5LISlg5C5vLZCn7dgMFVSNhSF9cuBEFrm/O2spDWEZeMnw4ZXYg==}
+  '@mswjs/interceptors@0.37.4':
+    resolution: {integrity: sha512-YUenGsnvhhuBkabJZrga8dv/8QFRBe/isTb5CYvmzaI/IISLIkKp8kItSu9URY9tsJLvkPkq2W48OU/piDvfnA==}
     engines: {node: '>=18'}
 
   '@next/env@15.0.3':
@@ -2573,14 +2574,14 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
-  '@shikijs/engine-oniguruma@1.24.4':
-    resolution: {integrity: sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==}
+  '@shikijs/engine-oniguruma@1.26.1':
+    resolution: {integrity: sha512-F5XuxN1HljLuvfXv7d+mlTkV7XukC1cawdtOo+7pKgPD83CAB1Sf8uHqP3PK0u7njFH0ZhoXE1r+0JzEgAQ+kg==}
 
-  '@shikijs/types@1.24.4':
-    resolution: {integrity: sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==}
+  '@shikijs/types@1.26.1':
+    resolution: {integrity: sha512-d4B00TKKAMaHuFYgRf3L0gwtvqpW4hVdVwKcZYbBfAAQXspgkbWqnFfuFl3MDH6gLbsubOcr+prcnsqah3ny7Q==}
 
-  '@shikijs/vscode-textmate@9.3.1':
-    resolution: {integrity: sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==}
+  '@shikijs/vscode-textmate@10.0.1':
+    resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -2765,11 +2766,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.68':
-    resolution: {integrity: sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==}
+  '@types/node@18.19.69':
+    resolution: {integrity: sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==}
 
-  '@types/node@20.17.10':
-    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
+  '@types/node@20.17.11':
+    resolution: {integrity: sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==}
 
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
@@ -3136,6 +3137,14 @@ packages:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
 
+  call-bind-apply-helpers@1.0.1:
+    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.3:
+    resolution: {integrity: sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -3500,6 +3509,10 @@ packages:
   domutils@3.2.1:
     resolution: {integrity: sha512-xWXmuRnN9OMP6ptPd2+H0cCbcYBULa5YDTbMm/2lvkWvNA3O4wcW+GvzooqBuNM8yy6pl3VIAeJTUUWUbfI5Fw==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -3554,8 +3567,20 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-object-atoms@1.0.0:
+    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -3765,6 +3790,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -3777,9 +3805,17 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.2.7:
+    resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
+    engines: {node: '>= 0.4'}
+
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -3817,6 +3853,10 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -3838,6 +3878,10 @@ packages:
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hast-util-classnames@3.0.0:
@@ -3873,8 +3917,8 @@ packages:
   hast-util-to-estree@2.3.3:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
 
-  hast-util-to-estree@3.1.0:
-    resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
+  hast-util-to-estree@3.1.1:
+    resolution: {integrity: sha512-IWtwwmPskfSmma9RpzCappDUitC8t5jhAynHhc1m2+5trOgsrp7txscUSavc5Ic8PATyAjfrCK1wgtxh2cICVQ==}
 
   hast-util-to-jsx-runtime@2.3.2:
     resolution: {integrity: sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg==}
@@ -4002,8 +4046,8 @@ packages:
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
-  intl-messageformat@10.7.10:
-    resolution: {integrity: sha512-hp7iejCBiJdW3zmOe18FdlJu8U/JsADSDiBPQhfdSeI8B9POtvPRvPh3nMlvhYayGMKLv6maldhR7y3Pf1vkpw==}
+  intl-messageformat@10.7.11:
+    resolution: {integrity: sha512-IB2N1tmI24k2EFH3PWjU7ivJsnWyLwOWOva0jnXFa29WzB6fb0JZ5EMQGu+XN5lDtjHYFo0/UooP67zBwUg7rQ==}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -4061,8 +4105,8 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+  is-generator-function@1.1.0:
+    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
     engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
@@ -4100,6 +4144,10 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4353,14 +4401,18 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
 
   mdast-util-find-and-replace@2.2.2:
     resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
 
-  mdast-util-find-and-replace@3.0.1:
-    resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
   mdast-util-from-markdown@1.3.1:
     resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
@@ -5341,6 +5393,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -5770,8 +5826,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
@@ -6286,8 +6342,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.6.1:
-    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -6882,37 +6938,37 @@ snapshots:
 
   '@fontsource/roboto-mono@5.1.0': {}
 
-  '@formatjs/ecma402-abstract@2.3.1':
+  '@formatjs/ecma402-abstract@2.3.2':
     dependencies:
-      '@formatjs/fast-memoize': 2.2.5
-      '@formatjs/intl-localematcher': 0.5.9
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/intl-localematcher': 0.5.10
       decimal.js: 10.4.3
       tslib: 2.8.1
 
-  '@formatjs/fast-memoize@2.2.5':
+  '@formatjs/fast-memoize@2.2.6':
     dependencies:
       tslib: 2.8.1
 
-  '@formatjs/icu-messageformat-parser@2.9.7':
+  '@formatjs/icu-messageformat-parser@2.9.8':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.3.1
-      '@formatjs/icu-skeleton-parser': 1.8.11
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/icu-skeleton-parser': 1.8.12
       tslib: 2.8.1
 
-  '@formatjs/icu-skeleton-parser@1.8.11':
+  '@formatjs/icu-skeleton-parser@1.8.12':
     dependencies:
-      '@formatjs/ecma402-abstract': 2.3.1
+      '@formatjs/ecma402-abstract': 2.3.2
       tslib: 2.8.1
 
-  '@formatjs/intl-localematcher@0.5.9':
+  '@formatjs/intl-localematcher@0.5.10':
     dependencies:
       tslib: 2.8.1
 
-  '@gerrit0/mini-shiki@1.24.4':
+  '@gerrit0/mini-shiki@1.25.1':
     dependencies:
-      '@shikijs/engine-oniguruma': 1.24.4
-      '@shikijs/types': 1.24.4
-      '@shikijs/vscode-textmate': 9.3.1
+      '@shikijs/engine-oniguruma': 1.26.1
+      '@shikijs/types': 1.26.1
+      '@shikijs/vscode-textmate': 10.0.1
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -6989,16 +7045,16 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@inquirer/confirm@5.1.1(@types/node@20.17.10)':
+  '@inquirer/confirm@5.1.1(@types/node@20.17.11)':
     dependencies:
-      '@inquirer/core': 10.1.2(@types/node@20.17.10)
-      '@inquirer/type': 3.0.2(@types/node@20.17.10)
-      '@types/node': 20.17.10
+      '@inquirer/core': 10.1.2(@types/node@20.17.11)
+      '@inquirer/type': 3.0.2(@types/node@20.17.11)
+      '@types/node': 20.17.11
 
-  '@inquirer/core@10.1.2(@types/node@20.17.10)':
+  '@inquirer/core@10.1.2(@types/node@20.17.11)':
     dependencies:
       '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@20.17.10)
+      '@inquirer/type': 3.0.2(@types/node@20.17.11)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -7011,9 +7067,9 @@ snapshots:
 
   '@inquirer/figures@1.0.9': {}
 
-  '@inquirer/type@3.0.2(@types/node@20.17.10)':
+  '@inquirer/type@3.0.2(@types/node@20.17.11)':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
 
   '@internationalized/date@3.6.0':
     dependencies:
@@ -7022,7 +7078,7 @@ snapshots:
   '@internationalized/message@3.1.6':
     dependencies:
       '@swc/helpers': 0.5.15
-      intl-messageformat: 10.7.10
+      intl-messageformat: 10.7.11
 
   '@internationalized/number@3.6.0':
     dependencies:
@@ -7070,7 +7126,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@ladle/react@4.1.2(@swc/helpers@0.5.15)(@types/node@20.17.10)(@types/react@18.3.11)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.83.0)(terser@5.37.0)(typescript@5.6.3)':
+  '@ladle/react@4.1.2(@swc/helpers@0.5.15)(@types/node@20.17.11)(@types/react@18.3.11)(acorn@8.14.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.83.0)(terser@5.37.0)(typescript@5.6.3)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.26.0
@@ -7082,8 +7138,8 @@ snapshots:
       '@ladle/react-context': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.0)
       '@mdx-js/react': 3.1.0(@types/react@18.3.11)(react@18.3.1)
-      '@vitejs/plugin-react': 4.3.2(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
-      '@vitejs/plugin-react-swc': 3.7.2(@swc/helpers@0.5.15)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+      '@vitejs/plugin-react': 4.3.2(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
+      '@vitejs/plugin-react-swc': 3.7.2(@swc/helpers@0.5.15)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       axe-core: 4.10.2
       boxen: 7.1.1
       chokidar: 3.6.0
@@ -7097,7 +7153,7 @@ snapshots:
       koa: 2.15.3
       koa-connect: 2.1.0
       lodash.merge: 4.6.2
-      msw: 2.7.0(@types/node@20.17.10)(typescript@5.6.3)
+      msw: 2.7.0(@types/node@20.17.11)(typescript@5.6.3)
       open: 10.1.0
       prism-react-renderer: 2.4.1(react@18.3.1)
       prop-types: 15.8.1
@@ -7111,8 +7167,8 @@ snapshots:
       remark-gfm: 4.0.0
       source-map: 0.7.4
       vfile: 6.0.3
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
-      vite-tsconfig-paths: 4.3.2(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite-tsconfig-paths: 4.3.2(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -7246,7 +7302,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@mswjs/interceptors@0.37.3':
+  '@mswjs/interceptors@0.37.4':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/logger': 0.3.0
@@ -8746,17 +8802,17 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@shikijs/engine-oniguruma@1.24.4':
+  '@shikijs/engine-oniguruma@1.26.1':
     dependencies:
-      '@shikijs/types': 1.24.4
-      '@shikijs/vscode-textmate': 9.3.1
+      '@shikijs/types': 1.26.1
+      '@shikijs/vscode-textmate': 10.0.1
 
-  '@shikijs/types@1.24.4':
+  '@shikijs/types@1.26.1':
     dependencies:
-      '@shikijs/vscode-textmate': 9.3.1
+      '@shikijs/vscode-textmate': 10.0.1
       '@types/hast': 3.0.4
 
-  '@shikijs/vscode-textmate@9.3.1': {}
+  '@shikijs/vscode-textmate@10.0.1': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -8908,7 +8964,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
     optional: true
 
   '@types/hast@2.3.10':
@@ -8923,7 +8979,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
     optional: true
 
   '@types/lodash@4.17.10': {}
@@ -8942,11 +8998,11 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.68':
+  '@types/node@18.19.69':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.17.10':
+  '@types/node@20.17.11':
     dependencies:
       undici-types: 6.19.8
 
@@ -9019,9 +9075,9 @@ snapshots:
     dependencies:
       '@vanilla-extract/private': 1.0.6
 
-  '@vanilla-extract/esbuild-plugin@2.3.11(@types/node@20.17.10)(esbuild@0.24.2)(sass-embedded@1.83.0)(terser@5.37.0)':
+  '@vanilla-extract/esbuild-plugin@2.3.11(@types/node@20.17.11)(esbuild@0.24.2)(sass-embedded@1.83.0)(terser@5.37.0)':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     optionalDependencies:
       esbuild: 0.24.2
     transitivePeerDependencies:
@@ -9036,7 +9092,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/integration@7.1.12(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)':
+  '@vanilla-extract/integration@7.1.12(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
@@ -9048,8 +9104,8 @@ snapshots:
       find-up: 5.0.0
       javascript-stringify: 2.1.0
       mlly: 1.7.3
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
-      vite-node: 1.6.0(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite-node: 1.6.0(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9062,9 +9118,9 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/next-plugin@2.4.6(@types/node@20.17.10)(next@15.0.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
+  '@vanilla-extract/next-plugin@2.4.6(@types/node@20.17.11)(next@15.0.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      '@vanilla-extract/webpack-plugin': 2.3.16(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))
       next: 15.0.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -9081,10 +9137,10 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
-  '@vanilla-extract/vite-plugin@4.0.16(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vanilla-extract/vite-plugin@4.0.16(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9097,9 +9153,9 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
+  '@vanilla-extract/webpack-plugin@2.3.16(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)(webpack@5.97.1(@swc/core@1.7.36(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
-      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      '@vanilla-extract/integration': 7.1.12(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
@@ -9116,25 +9172,25 @@ snapshots:
       - supports-color
       - terser
 
-  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.15)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@swc/core': 1.7.36(@swc/helpers@0.5.15)
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.3.2(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitejs/plugin-react@4.3.2(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitest/coverage-istanbul@2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0
@@ -9146,11 +9202,11 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+      vitest: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitest/coverage-istanbul@2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0
@@ -9162,7 +9218,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0)
+      vitest: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9173,23 +9229,23 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.0(@types/node@20.17.10)(typescript@5.6.3)
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      msw: 2.7.0(@types/node@20.17.11)(typescript@5.6.3)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.0(@types/node@20.17.10)(typescript@5.7.2)
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      msw: 2.7.0(@types/node@20.17.11)(typescript@5.7.2)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
 
   '@vitest/pretty-format@2.1.3':
     dependencies:
@@ -9220,10 +9276,10 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/web-worker@2.1.3(vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))':
+  '@vitest/web-worker@2.1.3(vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0))':
     dependencies:
       debug: 4.4.0
-      vitest: 2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
+      vitest: 2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9480,6 +9536,16 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       ylru: 1.4.0
+
+  call-bind-apply-helpers@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.3:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      get-intrinsic: 1.2.7
 
   callsites@3.1.0: {}
 
@@ -9778,6 +9844,12 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
@@ -9820,7 +9892,15 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.6.0: {}
+
+  es-object-atoms@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -10000,7 +10080,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
       require-like: 0.1.2
 
   events@3.3.0: {}
@@ -10117,13 +10197,33 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
 
+  get-intrinsic@1.2.7:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-port@7.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.0.0
 
   get-stream@6.0.1: {}
 
@@ -10170,6 +10270,8 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphql@16.10.0: {}
@@ -10188,6 +10290,10 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-classnames@3.0.0:
     dependencies:
@@ -10286,7 +10392,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-estree@3.1.0:
+  hast-util-to-estree@3.1.1:
     dependencies:
       '@types/estree': 1.0.6
       '@types/estree-jsx': 1.0.5
@@ -10301,7 +10407,7 @@ snapshots:
       mdast-util-mdxjs-esm: 2.0.1
       property-information: 6.5.0
       space-separated-tokens: 2.0.2
-      style-to-object: 0.4.4
+      style-to-object: 1.0.8
       unist-util-position: 5.0.0
       zwitch: 2.0.4
     transitivePeerDependencies:
@@ -10484,11 +10590,11 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
-  intl-messageformat@10.7.10:
+  intl-messageformat@10.7.11:
     dependencies:
-      '@formatjs/ecma402-abstract': 2.3.1
-      '@formatjs/fast-memoize': 2.2.5
-      '@formatjs/icu-messageformat-parser': 2.9.7
+      '@formatjs/ecma402-abstract': 2.3.2
+      '@formatjs/fast-memoize': 2.2.6
+      '@formatjs/icu-messageformat-parser': 2.9.8
       tslib: 2.8.1
 
   invariant@2.2.4:
@@ -10534,9 +10640,12 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-generator-function@1.0.10:
+  is-generator-function@1.1.0:
     dependencies:
+      call-bound: 1.0.3
+      get-proto: 1.0.1
       has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -10563,6 +10672,13 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.3
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   is-stream@2.0.1: {}
 
@@ -10623,7 +10739,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10729,7 +10845,7 @@ snapshots:
       fresh: 0.5.2
       http-assert: 1.5.0
       http-errors: 1.8.1
-      is-generator-function: 1.0.10
+      is-generator-function: 1.1.0
       koa-compose: 4.1.0
       koa-convert: 2.0.0
       on-finished: 2.4.1
@@ -10841,6 +10957,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  math-intrinsics@1.1.0: {}
+
   mdast-util-definitions@5.1.2:
     dependencies:
       '@types/mdast': 3.0.15
@@ -10854,7 +10972,7 @@ snapshots:
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
 
-  mdast-util-find-and-replace@3.0.1:
+  mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
@@ -10907,7 +11025,7 @@ snapshots:
       '@types/mdast': 4.0.4
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-find-and-replace: 3.0.1
+      mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
   mdast-util-gfm-footnote@1.0.2:
@@ -11738,13 +11856,13 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3):
+  msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.1(@types/node@20.17.10)
-      '@mswjs/interceptors': 0.37.3
+      '@inquirer/confirm': 5.1.1(@types/node@20.17.11)
+      '@mswjs/interceptors': 0.37.4
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
@@ -11763,13 +11881,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2):
+  msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.1(@types/node@20.17.10)
-      '@mswjs/interceptors': 0.37.3
+      '@inquirer/confirm': 5.1.1(@types/node@20.17.11)
+      '@mswjs/interceptors': 0.37.4
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
@@ -12012,23 +12130,23 @@ snapshots:
       mlly: 1.7.3
       pathe: 1.1.2
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.6.1):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.4.47
       tsx: 4.19.2
-      yaml: 2.6.1
+      yaml: 2.7.0
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.6.1):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.4.49
       tsx: 4.19.2
-      yaml: 2.6.1
+      yaml: 2.7.0
 
   postcss-value-parser@4.2.0: {}
 
@@ -12414,7 +12532,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.0
+      hast-util-to-estree: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12590,6 +12708,12 @@ snapshots:
       mri: 1.2.0
 
   safe-buffer@5.2.1: {}
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.3
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
 
@@ -12951,7 +13075,7 @@ snapshots:
       js-yaml: 4.1.0
       ofetch: 1.4.1
       package-manager-detector: 0.2.8
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       unconfig: 0.6.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -12998,7 +13122,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.1: {}
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.10:
     dependencies:
@@ -13072,7 +13196,7 @@ snapshots:
 
   tstl@2.5.16: {}
 
-  tsup@8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1):
+  tsup@8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -13083,7 +13207,7 @@ snapshots:
       execa: 5.1.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.29.1
       source-map: 0.8.0-beta.0
@@ -13100,7 +13224,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1):
+  tsup@8.3.0(@swc/core@1.7.36(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -13111,7 +13235,7 @@ snapshots:
       execa: 5.1.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.29.1
       source-map: 0.8.0-beta.0
@@ -13186,12 +13310,12 @@ snapshots:
 
   typedoc@0.27.6(typescript@5.7.2):
     dependencies:
-      '@gerrit0/mini-shiki': 1.24.4
+      '@gerrit0/mini-shiki': 1.25.1
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       typescript: 5.7.2
-      yaml: 2.6.1
+      yaml: 2.7.0
 
   typescript@5.6.3: {}
 
@@ -13365,13 +13489,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.0(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0):
+  vite-node@1.6.0(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13383,12 +13507,12 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.3(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0):
+  vite-node@2.1.3(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13400,43 +13524,43 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.6.3)
     optionalDependencies:
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.0.1(typescript@5.7.2)(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)):
+  vite-tsconfig-paths@5.0.1(typescript@5.7.2)(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.7.2)
     optionalDependencies:
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0):
+  vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.29.1
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
       fsevents: 2.3.3
       sass-embedded: 1.83.0
       terser: 5.37.0
 
-  vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0):
+  vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(sass-embedded@1.83.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.10)(typescript@5.6.3))(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.11)(typescript@5.6.3))(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -13448,14 +13572,14 @@ snapshots:
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
-      vite-node: 2.1.3(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite-node: 2.1.3(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less
@@ -13468,10 +13592,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.3(@types/node@20.17.10)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0):
+  vitest@2.1.3(@types/node@20.17.11)(jsdom@25.0.1)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(sass-embedded@1.83.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.10)(typescript@5.7.2))(vite@5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(msw@2.7.0(@types/node@20.17.11)(typescript@5.7.2))(vite@5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -13483,14 +13607,14 @@ snapshots:
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.9(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
-      vite-node: 2.1.3(@types/node@20.17.10)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite: 5.4.9(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
+      vite-node: 2.1.3(@types/node@20.17.11)(sass-embedded@1.83.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less
@@ -13616,7 +13740,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.6.1: {}
+  yaml@2.7.0: {}
 
   yargs-parser@21.1.1: {}
 
@@ -13643,4 +13767,4 @@ snapshots:
   zx@8.1.9:
     optionalDependencies:
       '@types/fs-extra': 11.0.4
-      '@types/node': 20.17.10
+      '@types/node': 20.17.11


### PR DESCRIPTION
## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

- `pnpm run clean`
- `pnpm install`
- `pnpm run build`
- `pnpm --filter=@accelint/docs build:typedoc`
- confirm that the generated files do not have the header link 

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

other display options can be found here: https://typedoc-plugin-markdown.org/docs/options/display-options
