### PR TITLE
chore: embed ladle in typedoc

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "typedoc",
+    "build:ladle": "pnpm --filter=@accelint/design-system exec ladle build -o ../../apps/docs/dist/ladle --base ladle",
+    "build": "typedoc && pnpm run build:ladle",
     "serve": "http-server ./dist -p 3000"
   },
   "dependencies": {

--- a/apps/docs/typedoc.config.mjs
+++ b/apps/docs/typedoc.config.mjs
@@ -16,6 +16,7 @@ export default {
   entryPoints: ['../../packages/*'],
   packageOptions: {
     entryPoints: ['src/index.ts'],
+    projectDocuments: ['src/**/*.md'],
   },
   out: 'dist/',
   disableSources: true,

--- a/packages/design-system/src/component-playground.md
+++ b/packages/design-system/src/component-playground.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+---
+title: Component Playground
+---
+
+<iframe src="/ladle/index.html" style="width: 100%; min-height: 900px"></iframe>


### PR DESCRIPTION
![Screenshot 2025-01-06 at 11 58 13 AM](https://github.com/user-attachments/assets/0b09f27c-e413-4920-9467-fbc3ca0e580a)

also updated the link 