### PR TITLE
chore: remove slow hook. mutative hooks must be pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,11 +3,6 @@ pre-commit:
     generate-license:
       run: pnpm run license "--files={staged_files}"
       stage_fixed: true
-
-pre-push:
-  commands:
-    lint:
-      run: pnpm run lint
     format:
       run: pnpm run format
       stage_fixed: true


### PR DESCRIPTION
## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

- make a change
- commit
- formatter, import sorting, and license generation scripts should run

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

- linting took too long, so we're are CI handle that
- stage_fixed only works in the `pre-commit` hook, so in order to get formatting and import sorting automagically, those need to be pre-commit. it takes about 1.5 seconds.