### PR TITLE
Fix: Import correct design system useContextProps hook

### DIFF
--- a/.changeset/three-comics-attend.md
+++ b/.changeset/three-comics-attend.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+---
+"@accelint/design-system": patch
+---
+
+Changes import to use design system useContextProps hook

--- a/packages/design-system/src/components/picker/picker.tsx
+++ b/packages/design-system/src/components/picker/picker.tsx
@@ -11,8 +11,8 @@
  */
 
 import {
-  type ForwardedRef,
   createContext,
+  type ForwardedRef,
   forwardRef,
   useCallback,
   useMemo,
@@ -26,9 +26,8 @@ import {
   type ListBoxRenderProps,
   Provider,
   Section,
-  useContextProps,
 } from 'react-aria-components';
-import { useDefaultProps, useTheme } from '../../hooks';
+import { useContextProps, useDefaultProps, useTheme } from '../../hooks';
 import { callRenderProps, inlineVars, mergeClassNames } from '../../utils';
 import {
   pickerClassNames,

--- a/packages/design-system/src/components/popover/popover.tsx
+++ b/packages/design-system/src/components/popover/popover.tsx
@@ -11,23 +11,27 @@
  */
 
 import {
-  type ForwardedRef,
-  type HTMLAttributes,
   createContext,
+  type ForwardedRef,
   forwardRef,
+  type HTMLAttributes,
   useCallback,
   useMemo,
 } from 'react';
 import {
   type ContextValue,
   DEFAULT_SLOT,
-  Provider,
   Dialog as RACDialog,
   Popover as RACPopover,
   type PopoverRenderProps as RACPopoverRenderProps,
-  useContextProps,
+  Provider,
 } from 'react-aria-components';
-import { useDefaultProps, useSlot, useTheme } from '../../hooks';
+import {
+  useContextProps,
+  useDefaultProps,
+  useSlot,
+  useTheme,
+} from '../../hooks';
 import { headings } from '../../styles';
 import { callRenderProps, inlineVars, mergeClassNames } from '../../utils';
 import { AriaHeadingContext } from '../aria';

--- a/packages/design-system/src/components/tabs/tabs.tsx
+++ b/packages/design-system/src/components/tabs/tabs.tsx
@@ -12,8 +12,8 @@
 
 import {
   Children,
-  type ForwardedRef,
   createContext,
+  type ForwardedRef,
   forwardRef,
   useCallback,
   useMemo,
@@ -21,22 +21,26 @@ import {
 import {
   type ContextValue,
   Provider,
+  type SlotProps,
   Tab as RACTab,
   TabList as RACTabList,
   TabPanel as RACTabPanel,
   Tabs as RACTabs,
-  type SlotProps,
-  useContextProps,
 } from 'react-aria-components';
 import type { RequiredDeep } from 'type-fest';
-import { useDefaultProps, usePropagatingPress, useTheme } from '../../hooks';
+import {
+  useContextProps,
+  useDefaultProps,
+  usePropagatingPress,
+  useTheme,
+} from '../../hooks';
 import { callRenderProps, inlineVars, mergeClassNames } from '../../utils';
 import {
   tabListStateVars,
-  tabPanelStateVars,
   tabPanelsStateVars,
-  tabStateVars,
+  tabPanelStateVars,
   tabsClassNames,
+  tabStateVars,
 } from './tabs.css';
 import type {
   TabListProps,
@@ -134,8 +138,21 @@ export const TabList = forwardRef(function TabList<T extends object>(
   props: TabListProps<T>,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
+  console.log({ beforeContext: props.classNames });
+
   [props, ref] = useContextProps(props, ref, TabListContext);
+
+  console.log({ afterContext: props.classNames });
+
   props = useDefaultProps(props, 'TabList');
+
+  console.log({ afterDefaults: props.classNames });
+
+  // const something = useContext(TabListContext);
+  //
+  // console.log({tabListClassnames: props.classNames});
+  //
+  // console.log({something});
 
   const {
     children,
@@ -235,6 +252,8 @@ export const Tab = forwardRef(function Tab(
     () => mergeClassNames(tabsClassNames, theme.Tabs, classNamesProp),
     [theme.Tabs, classNamesProp],
   );
+
+  console.log(classNames);
 
   const style = useCallback(
     (renderProps: TabRenderProps) => inlineVars(tabStateVars, renderProps),

--- a/packages/design-system/src/components/tabs/tabs.tsx
+++ b/packages/design-system/src/components/tabs/tabs.tsx
@@ -138,21 +138,8 @@ export const TabList = forwardRef(function TabList<T extends object>(
   props: TabListProps<T>,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
-  console.log({ beforeContext: props.classNames });
-
   [props, ref] = useContextProps(props, ref, TabListContext);
-
-  console.log({ afterContext: props.classNames });
-
   props = useDefaultProps(props, 'TabList');
-
-  console.log({ afterDefaults: props.classNames });
-
-  // const something = useContext(TabListContext);
-  //
-  // console.log({tabListClassnames: props.classNames});
-  //
-  // console.log({something});
 
   const {
     children,
@@ -252,8 +239,6 @@ export const Tab = forwardRef(function Tab(
     () => mergeClassNames(tabsClassNames, theme.Tabs, classNamesProp),
     [theme.Tabs, classNamesProp],
   );
-
-  console.log(classNames);
 
   const style = useCallback(
     (renderProps: TabRenderProps) => inlineVars(tabStateVars, renderProps),

--- a/packages/design-system/src/components/textarea/textarea.tsx
+++ b/packages/design-system/src/components/textarea/textarea.tsx
@@ -14,9 +14,9 @@ import { useFocusRing } from '@react-aria/focus';
 import { useHover } from '@react-aria/interactions';
 import { useControlledState } from '@react-stately/utils';
 import {
+  createContext,
   type FormEvent,
   type ForwardedRef,
-  createContext,
   forwardRef,
   useCallback,
   useEffect,
@@ -26,9 +26,8 @@ import {
   type ContextValue,
   TextAreaContext as RACTextAreaContext,
   type TextAreaProps as RACTextAreaProps,
-  useContextProps,
 } from 'react-aria-components';
-import { useDefaultProps, useTheme } from '../../hooks';
+import { useContextProps, useDefaultProps, useTheme } from '../../hooks';
 import { inputs } from '../../styles';
 import { inlineVars, mergeClassNames, mergeProps } from '../../utils';
 import { textAreaClassNames, textAreaStateVars } from './textarea.css';

--- a/packages/design-system/src/components/tooltip/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip/tooltip.tsx
@@ -12,8 +12,8 @@
 
 import { useFocusable } from '@react-aria/focus';
 import {
-  type ForwardedRef,
   createContext,
+  type ForwardedRef,
   forwardRef,
   useCallback,
   useMemo,
@@ -22,9 +22,8 @@ import {
   type ContextValue,
   Tooltip as RACTooltip,
   type TooltipRenderProps,
-  useContextProps,
 } from 'react-aria-components';
-import { useDefaultProps, useTheme } from '../../hooks';
+import { useContextProps, useDefaultProps, useTheme } from '../../hooks';
 import { bodies } from '../../styles';
 import { callRenderProps, inlineVars, mergeClassNames } from '../../utils';
 import {


### PR DESCRIPTION
Closes *no associated github issue*

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

We discovered an issue where classNames was not being merged in through context as expected from the `Tabs` component to the `TabList` component. The root cause was that the component was using the `useContextProps` directly from the React Aria Component library and not the more robust implementation created for the design system.

This PR makes sure that all the components use the correct design system hook.
