### PR TITLE
Fix/z index override

### DIFF
--- a/.changeset/eighty-rules-perform.md
+++ b/.changeset/eighty-rules-perform.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+---
+"@accelint/design-system": patch
+---
+
+Enforces design system theme z-index ordering for popover component

--- a/packages/design-system/src/components/options/options.css.ts
+++ b/packages/design-system/src/components/options/options.css.ts
@@ -1,12 +1,19 @@
-import {
-  createContainer,
-  createThemeContract,
-  fallbackVar,
-  style,
-} from '@vanilla-extract/css';
-import { layers, radiusVars, sizeVars, surfaces } from '../../styles';
-import { containerQueries } from '../../utils';
-import type { OptionsClassNames, OptionsItemState } from './types';
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {createContainer, createThemeContract, fallbackVar, style,} from '@vanilla-extract/css';
+import {layers, radiusVars, sizeVars, surfaces, zIndexVars,} from '../../styles';
+import {containerQueries} from '../../utils';
+import type {OptionsClassNames, OptionsItemState} from './types';
 
 export const optionsContainers = {
   options: createContainer(),
@@ -98,6 +105,7 @@ export const optionsClassNames: OptionsClassNames = {
         [layers.components.l1]: {
           containerName: optionsContainers.options,
           display: 'block',
+          zIndex: `${zIndexVars.popover} !important`, // Need to override inline style set by React Aria
         },
       },
     }),
@@ -191,7 +199,7 @@ export const optionsClassNames: OptionsClassNames = {
           '@container': containerQueries<OptionsItemState>(
             optionsItemStateVars,
             {
-              query: { isDisabled: true },
+              query: {isDisabled: true},
               cursor: 'not-allowed',
             },
           ),
@@ -215,7 +223,7 @@ export const optionsClassNames: OptionsClassNames = {
           '@container': containerQueries<OptionsItemState>(
             optionsItemStateVars,
             {
-              query: { hasDescription: false },
+              query: {hasDescription: false},
               gridRowStart: 'label',
               gridRowEnd: 'description',
             },

--- a/packages/design-system/src/components/popover/popover.css.ts
+++ b/packages/design-system/src/components/popover/popover.css.ts
@@ -1,11 +1,18 @@
-import {
-  createContainer,
-  createThemeContract,
-  fallbackVar,
-  style,
-} from '@vanilla-extract/css';
-import { layers, radiusVars, surfaces } from '../../styles';
-import type { PopoverClassNames } from './types';
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {createContainer, createThemeContract, fallbackVar, style,} from '@vanilla-extract/css';
+import {layers, radiusVars, surfaces, zIndexVars} from '../../styles';
+import type {PopoverClassNames} from './types';
 
 export const popoverContainer = createContainer();
 
@@ -63,6 +70,7 @@ export const popoverClassNames: PopoverClassNames = {
         [layers.components.l1]: {
           containerName: popoverContainer,
           display: 'block',
+          zIndex: `${zIndexVars.popover} !important`, // Need to override inline style set by React Aria
         },
       },
     }),


### PR DESCRIPTION
Closes https://github.com/gohypergiant/standard-toolkit/issues/178

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

When running the ladle stories, go into any of the stories for the popover component and add a tooltip. Observe before the fix that the tooltip renders under the popover before the z-index change, and after the fix, over the popover.

![image](https://github.com/user-attachments/assets/5fef0a66-9f53-44b1-a696-dc7205ae3051)

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

