### PR TITLE
Feat: Remove requirement for listsAsArrays in Querybuilder

### DIFF
--- a/packages/design-system/src/components/query-builder/query-builder.stories.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.stories.tsx
@@ -81,8 +81,8 @@ export default {
       control: {
         type: 'boolean',
       },
-      defaultValue: true
-    }
+      defaultValue: true,
+    },
   },
 } satisfies StoryDefault<QueryBuilderProps>;
 

--- a/packages/design-system/src/components/query-builder/query-builder.stories.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.stories.tsx
@@ -77,6 +77,12 @@ export default {
       options: ['sm', 'lg'],
       defaultValue: 'sm',
     },
+    listsAsArrays: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true
+    }
   },
 } satisfies StoryDefault<QueryBuilderProps>;
 

--- a/packages/design-system/src/components/query-builder/query-builder.tsx
+++ b/packages/design-system/src/components/query-builder/query-builder.tsx
@@ -237,7 +237,6 @@ export function QueryBuilder({
           controlElements={controlElements}
           controlClassnames={controlClassNames}
           disabled={disabled}
-          listsAsArrays
         />
       </div>
     </Provider>

--- a/packages/design-system/src/components/query-builder/types.ts
+++ b/packages/design-system/src/components/query-builder/types.ts
@@ -156,8 +156,8 @@ type BaseQueryBuilderProps = {
  * Omitted props are currently unsupported functionality
  */
 export type QueryBuilderProps = Partial<
-  Omit<DefaultRQBProps, 'showCombinatorsBetweenRules' | 'listsAsArrays'> &
-    BaseQueryBuilderProps
+  Omit<DefaultRQBProps, 'showCombinatorsBetweenRules'> &
+  BaseQueryBuilderProps
 >;
 
 export type ActionProps = AsType<RQBActionProps>;

--- a/packages/design-system/src/components/query-builder/types.ts
+++ b/packages/design-system/src/components/query-builder/types.ts
@@ -156,8 +156,7 @@ type BaseQueryBuilderProps = {
  * Omitted props are currently unsupported functionality
  */
 export type QueryBuilderProps = Partial<
-  Omit<DefaultRQBProps, 'showCombinatorsBetweenRules'> &
-  BaseQueryBuilderProps
+  Omit<DefaultRQBProps, 'showCombinatorsBetweenRules'> & BaseQueryBuilderProps
 >;
 
 export type ActionProps = AsType<RQBActionProps>;


### PR DESCRIPTION
Closes <!-- Github issue # here -->

There is a boolean prop available `listsAsArrays` on the [React Querybuilder](https://react-querybuilder.js.org/docs/components/querybuilder#listsasarrays) component that changes the structure of the data store for those operators that store multiple values. When enabled, `listsAsArrays` stores the data as an array of values and when disabled, the list is stored as a comma-separated string.

Previously, the `listsAsArrays` value was locked into `true` to simplify some of the processing and validation, but since there is a desire to have more flexibility with the filtering (for example, there are CQL queries where the value can be passed through as comma separated strings without any further processing) then this PR makes `listsAsArrays` a prop that can be set per instance.

Value of a multi-value rule with `listsAsArrays` enabled: 
![CleanShot 2025-02-05 at 11 30 53](https://github.com/user-attachments/assets/53965ca5-656b-4931-b550-9dedb8602fa3)

Value of a multi-value rules with `listsAsArrays` disabled:
![CleanShot 2025-02-05 at 11 32 33](https://github.com/user-attachments/assets/c98b0577-a760-4e01-a292-08a7d038d7c2)

To be able to handle this isomorphically, RQB provides a hook `useValueEditor` that normalizes the value into an array for processing (no matter how it is stored) which we use to draw the value editor components:

https://github.com/gohypergiant/standard-toolkit/blob/ed5ca137073b9f93eb0eb4c74fa043d9ba8529ac/packages/design-system/src/components/query-builder/value-editor.tsx#L203

Note that whether `listsAsArrays` is set to true or false, the value is always processed as an array in the `ValueEditor` component above:

Value with `listsAsArrays` enabled:
![CleanShot 2025-02-05 at 11 40 27](https://github.com/user-attachments/assets/130b11ee-5e74-4884-8cea-0fb500fb8c68)


Value with `listsAsArrays` disabled:
![CleanShot 2025-02-05 at 11 38 00](https://github.com/user-attachments/assets/8a322fdc-bbde-49bd-96f3-2f862244e6b9)

The only real downstream effect of this change is on validation, which needs differentiated handling on the part of the application developer.



## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

To see this change in action, run the design system stories off this branch and navigate to the querybuilder story. There is now a control that allows for toggling the `listsAsArrays` on and off in the story. Note that the validation only works in the story when the `listsAsArrays` is enabled.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

