### PR TITLE
Feat: Add read-only tree node property

### DIFF
--- a/packages/design-system/.ladle/theme/tree.css.ts
+++ b/packages/design-system/.ladle/theme/tree.css.ts
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import { style } from '@vanilla-extract/css';
 import {
   type ThemeContext,
@@ -125,6 +137,14 @@ export const Tree: ThemeContext['Tree'] = {
           vars: assignPartialVars(treeColorVars, {
             bar: {
               color: semanticColorVars.foreground.interactive.primary.bold,
+            },
+          }),
+        },
+        {
+          query: { isDisabled: true },
+          vars: assignPartialVars(treeColorVars, {
+            bar: {
+              color: genericColorVars.neutral.v03,
             },
           }),
         },

--- a/packages/design-system/src/components/tree/tree.css.ts
+++ b/packages/design-system/src/components/tree/tree.css.ts
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import {
   createContainer,
   createThemeContract,
@@ -81,6 +93,7 @@ export const treeItemStateVars = createThemeContract({
   isHovered: '',
   isLastChild: '',
   isPressed: '',
+  isReadOnly: '',
   isSelected: '',
   isViewable: '',
   isVisible: '',

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -279,7 +279,7 @@ const nodes = [
     label: 'Produce',
     isExpanded: true,
     isViewable: true,
-    isReadOnly: false,
+    isReadOnly: true,
     types: ['produce'],
     nodes: [
       {

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -71,113 +71,136 @@ export default {
   },
 } satisfies StoryDefault<TreeProps<unknown>>;
 
+const icons = {
+  eyeOpen: (
+    <Icon fill='none' stroke='currentcolor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Open Eye Icon</title>
+        <path d='M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0' />
+        <circle cx='12' cy='12' r='3' />
+      </svg>
+    </Icon>
+  ),
+  eyeClosed: (
+    <Icon fill='none' stroke='currentcolor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Closed Eye Icon</title>
+        <path d='M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49' />
+        <path d='M14.084 14.158a3 3 0 0 1-4.242-4.242' />
+        <path d='M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143' />
+        <path d='m2 2 20 20' />
+      </svg>
+    </Icon>
+  ),
+  lock: (
+    <Icon>
+      <svg
+        className='MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1wmkh38'
+        focusable='false'
+        aria-hidden='true'
+        viewBox='0 0 24 24'
+        data-testid='LockIcon'
+      >
+        <path d='M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2m-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2m3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1s3.1 1.39 3.1 3.1z' />
+      </svg>
+    </Icon>
+  ),
+  chevronExpanded: (
+    <Icon fill='none' stroke='currentcolor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Chevron Down Icon</title>
+        <path d='m6 9 6 6 6-6' />
+      </svg>
+    </Icon>
+  ),
+  chevronCollapsed: (
+    <Icon fill='none' stroke='currentcolor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Chevron Right Icon</title>
+        <path d='m9 18 6-6-6-6' />
+      </svg>
+    </Icon>
+  ),
+  checkmark: (
+    <Icon fill='none' stroke='currentColor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Checkmark Icon</title>
+        <path d='M20 6 9 17l-5-5' />
+      </svg>
+    </Icon>
+  ),
+  dragIcon: (
+    <Icon fill='none' stroke='currentcolor'>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        strokeWidth='1'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <title>Drag Icon</title>
+        <circle cx='9' cy='12' r='1' />
+        <circle cx='9' cy='5' r='1' />
+        <circle cx='9' cy='19' r='1' />
+        <circle cx='15' cy='12' r='1' />
+        <circle cx='15' cy='5' r='1' />
+        <circle cx='15' cy='19' r='1' />
+      </svg>
+    </Icon>
+  ),
+};
+
 function Node() {
   return (
     <>
       <ToggleButton slot='visibility'>
-        {({ isSelected }) =>
-          isSelected ? (
-            <Icon fill='none' stroke='currentcolor'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                viewBox='0 0 24 24'
-                strokeWidth='1'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              >
-                <title>Open Eye Icon</title>
-                <path d='M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0' />
-                <circle cx='12' cy='12' r='3' />
-              </svg>
-            </Icon>
-          ) : (
-            <Icon fill='none' stroke='currentcolor'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                viewBox='0 0 24 24'
-                strokeWidth='1'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              >
-                <title>Closed Eye Icon</title>
-                <path d='M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49' />
-                <path d='M14.084 14.158a3 3 0 0 1-4.242-4.242' />
-                <path d='M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143' />
-                <path d='m2 2 20 20' />
-              </svg>
-            </Icon>
-          )
-        }
+        {({ isSelected, isDisabled }) => {
+          if (isDisabled) {
+            return icons.lock;
+          }
+          return isSelected ? icons.eyeOpen : icons.eyeClosed;
+        }}
       </ToggleButton>
       <ToggleButton slot='expansion'>
         {({ isSelected }) =>
-          isSelected ? (
-            <Icon fill='none' stroke='currentcolor'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                viewBox='0 0 24 24'
-                strokeWidth='1'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              >
-                <title>Chevron Down Icon</title>
-                <path d='m6 9 6 6 6-6' />
-              </svg>
-            </Icon>
-          ) : (
-            <Icon fill='none' stroke='currentcolor'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                viewBox='0 0 24 24'
-                strokeWidth='1'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              >
-                <title>Chevron Right Icon</title>
-                <path d='m9 18 6-6-6-6' />
-              </svg>
-            </Icon>
-          )
+          isSelected ? icons.chevronExpanded : icons.chevronCollapsed
         }
       </ToggleButton>
       <AriaText slot='description' />
       <Checkbox slot='selection'>
-        {({ isSelected }) =>
-          isSelected ? (
-            <Icon fill='none' stroke='currentColor'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                viewBox='0 0 24 24'
-                strokeWidth='1'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              >
-                <title>Checkmark Icon</title>
-                <path d='M20 6 9 17l-5-5' />
-              </svg>
-            </Icon>
-          ) : null
-        }
+        {({ isSelected }) => (isSelected ? icons.checkmark : null)}
       </Checkbox>
-      <Button slot='drag'>
-        <Icon fill='none' stroke='currentcolor'>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            viewBox='0 0 24 24'
-            strokeWidth='1'
-            strokeLinecap='round'
-            strokeLinejoin='round'
-          >
-            <title>Drag Icon</title>
-            <circle cx='9' cy='12' r='1' />
-            <circle cx='9' cy='5' r='1' />
-            <circle cx='9' cy='19' r='1' />
-            <circle cx='15' cy='12' r='1' />
-            <circle cx='15' cy='5' r='1' />
-            <circle cx='15' cy='19' r='1' />
-          </svg>
-        </Icon>
-      </Button>
+      <Button slot='drag'>{icons.dragIcon}</Button>
     </>
   );
 }
@@ -294,7 +317,7 @@ const nodes = [
         label: 'Banana',
         type: 'produce',
         isViewable: true,
-        isReadOnly: true,
+        isReadOnly: false,
       },
       {
         id: 'c',

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -279,6 +279,7 @@ const nodes = [
     label: 'Produce',
     isExpanded: true,
     isViewable: true,
+    isReadOnly: false,
     types: ['produce'],
     nodes: [
       {
@@ -286,18 +287,21 @@ const nodes = [
         label: 'Apple',
         type: 'produce',
         isViewable: true,
+        isReadOnly: true,
       },
       {
         id: 'b',
         label: 'Banana',
         type: 'produce',
         isViewable: true,
+        isReadOnly: true,
       },
       {
         id: 'c',
         label: 'Carrot',
         type: 'produce',
         isViewable: false,
+        isReadOnly: false,
       },
     ],
   },

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -465,6 +465,7 @@ export function TreeItem<T>({
         isLastChild,
         isViewable: !!node.value.isViewable,
         isVisible: !!node.value.isVisible,
+        isReadOnly: !!node.value.isReadOnly,
       }),
     [node.children.length, node.value, index, isFirstChild, isLastChild],
   );
@@ -492,6 +493,7 @@ export function TreeItem<T>({
               ...mapping.visibility[size],
               classNames: classNames?.item?.visibility,
               isSelected: !!node.value.isViewable,
+              isDisabled: !!node.value.isReadOnly,
               onPress: handleToggleVisibility,
             },
           },
@@ -625,6 +627,7 @@ export function TreeItem<T>({
   return (
     <GridListItem
       {...rest}
+      isDisabled={!!node.value.isReadOnly}
       className={classNames?.item?.container}
       style={style}
       textValue={node.value.label}

--- a/packages/design-system/src/hooks/use-tree/use-tree.test.ts
+++ b/packages/design-system/src/hooks/use-tree/use-tree.test.ts
@@ -218,4 +218,28 @@ describe('useTree', () => {
       true,
     );
   });
+
+  it('should not toggle visibility if read-only node', () => {
+    const { result } = setup({
+      allowsVisibility: true,
+      nodes: [
+        { id: 'foo', label: 'Foo', isViewable: true, isReadOnly: true }, //
+        { id: 'bar', label: 'Bar', isViewable: true, isReadOnly: false },
+      ],
+    });
+
+    act(() =>
+      result.current.actions.toggleIsViewable(new Set(['foo', 'bar']), false),
+    );
+
+    expect(result.current.tree.children[0]?.value).toHaveProperty(
+      'isViewable',
+      true,
+    );
+
+    expect(result.current.tree.children[1]?.value).toHaveProperty(
+      'isViewable',
+      false,
+    );
+  });
 });

--- a/packages/design-system/src/hooks/use-tree/use-tree.ts
+++ b/packages/design-system/src/hooks/use-tree/use-tree.ts
@@ -313,9 +313,11 @@ export function useTree<T>({
             return;
           }
 
-          update(key, {
-            isViewable: isViewable ?? !value.isViewable,
-          });
+          if (!value.isReadOnly) {
+            update(key, {
+              isViewable: isViewable ?? !value.isViewable,
+            });
+          }
         });
       }
 
@@ -332,7 +334,9 @@ export function useTree<T>({
             return;
           }
 
-          update(key, { isViewable: value.isViewable });
+          if (!value.isReadOnly) {
+            update(key, { isViewable: value.isViewable });
+          }
         },
       );
     },

--- a/packages/design-system/src/types/use-tree.ts
+++ b/packages/design-system/src/types/use-tree.ts
@@ -20,6 +20,7 @@ export type TreeItemNode<T> = {
   value?: T;
   isViewable?: boolean; // mutable
   isVisible?: boolean; // computed
+  isReadOnly?: boolean;
 };
 
 export type TreeGroupNode<T> = TreeItemNode<T> & {


### PR DESCRIPTION
Closes https://github.com/gohypergiant/standard-toolkit/issues/186

Adds the concept of a read-only tree node. Note that the story (and the visual choices to indicate "read only") are just used here to demonstrate the concept and can be themed per the application.

![CleanShot 2025-02-26 at 09 49 22@2x](https://github.com/user-attachments/assets/92597a5a-b820-45a9-9138-246f8b661163)


## ✅ Pull Request Checklist:
- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.

## 📝 Test Instructions:

Run a preview of the design system stories and take the new property for a whirl. Note that if a read-only child has a parent that is NOT read only, then it is still possible to change the visibility of that item via the parent. For a truly "this can never be touched" the item either needs to be standalone or in a group that is also read-only.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

