### PR TITLE
fix: no outline in input and text area

### DIFF
--- a/packages/design-system/src/components/input/input.css.ts
+++ b/packages/design-system/src/components/input/input.css.ts
@@ -72,6 +72,7 @@ export const inputClassNames: InputClassNames = {
         borderRadius: radiusVars.md,
         background: inputColorVars.background,
         fontFamily: typographyVars.mono,
+        outline: 'none',
         color: inputColorVars.color,
         '::-webkit-inner-spin-button': {
           display: 'none',

--- a/packages/design-system/src/components/textarea/textarea.css.ts
+++ b/packages/design-system/src/components/textarea/textarea.css.ts
@@ -67,6 +67,7 @@ export const textAreaClassNames: TextAreaClassNames = {
         fontFamily: typographyVars.mono,
         color: textAreaColorVars.color,
         overflow: 'auto',
+        outline: 'none',
         resize: textAreaStateVars.resize,
         selectors: {
           '&[contenteditable]:empty::before': {


### PR DESCRIPTION
Closes https://jira-cbc2.cce.af.mil/browse/ABMSCBCDEV-28153

As per ticket:
Current Behavior: <text-field> current active state is showing a combination of [hover] and [focus] states together
Desired Behavior: <text-field> current active state shows [focus] state

Removed outline for text area and input.

Before : ![Screenshot 2025-02-25 at 10 37 27 AM](https://github.com/user-attachments/assets/3f73b7a0-ab09-4eb6-bb1e-c621a63dd761)
After: ![Screenshot 2025-02-25 at 10 36 26 AM](https://github.com/user-attachments/assets/bf2d0195-54e5-4c62-8263-7a54bfaee6c1)|

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [Jira Issue](https://jira-cbc2.cce.af.mil/browse/ABMSCBCDEV-28153).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

