### PR TITLE
Fix: incorrect tooltip children prop

### DIFF
--- a/.changeset/lucky-chicken-melt.md
+++ b/.changeset/lucky-chicken-melt.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+---
+"@accelint/design-system": patch
+---
+
+use correct type for Tooltip component children

--- a/packages/design-system/src/components/tooltip/types.ts
+++ b/packages/design-system/src/components/tooltip/types.ts
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import type { PropsWithChildren } from 'react';
 import type {
   TooltipProps as RACTooltipProps,
@@ -53,7 +65,7 @@ export type TooltipTargetState = Required<
 
 export type TooltipProps = Omit<
   RACTooltipProps,
-  'className' | 'style' | 'UNSTABLE_portalContainer'
+  'children' | 'className' | 'style' | 'UNSTABLE_portalContainer'
 > &
   BaseTooltipProps;
 

--- a/packages/design-system/src/components/tooltip/types.ts
+++ b/packages/design-system/src/components/tooltip/types.ts
@@ -12,8 +12,8 @@
 
 import type { PropsWithChildren } from 'react';
 import type {
-  TooltipProps as RacTooltipProps,
-  TooltipRenderProps as RacTooltipRenderProps,
+  TooltipProps as RACTooltipProps,
+  TooltipRenderProps as RACTooltipRenderProps,
 } from 'react-aria-components';
 import type { PartialDeep } from 'type-fest';
 import type { RenderPropsChildren } from '../../types';
@@ -33,7 +33,7 @@ export type TooltipMapping = {
   font: string;
 };
 
-export type TooltipRenderProps = RacTooltipRenderProps & {
+export type TooltipRenderProps = RACTooltipRenderProps & {
   /**
    * If the tooltip is visible
    */
@@ -56,7 +56,7 @@ type BaseTooltipTargetProps = BaseProps & {
 
 export type TooltipState = Omit<TooltipRenderProps, 'state'> &
   Required<
-    Pick<RacTooltipProps, 'containerPadding' | 'crossOffset' | 'offset'>
+    Pick<RACTooltipProps, 'containerPadding' | 'crossOffset' | 'offset'>
   >;
 
 export type TooltipTargetState = Required<
@@ -64,7 +64,7 @@ export type TooltipTargetState = Required<
 >;
 
 export type TooltipProps = Omit<
-  RacTooltipProps,
+  RACTooltipProps,
   'children' | 'className' | 'style' | 'UNSTABLE_portalContainer'
 > &
   BaseTooltipProps;

--- a/packages/design-system/src/components/tooltip/types.ts
+++ b/packages/design-system/src/components/tooltip/types.ts
@@ -12,8 +12,8 @@
 
 import type { PropsWithChildren } from 'react';
 import type {
-  TooltipProps as RACTooltipProps,
-  TooltipRenderProps as RACTooltipRenderProps,
+  TooltipProps as RacTooltipProps,
+  TooltipRenderProps as RacTooltipRenderProps,
 } from 'react-aria-components';
 import type { PartialDeep } from 'type-fest';
 import type { RenderPropsChildren } from '../../types';
@@ -33,7 +33,7 @@ export type TooltipMapping = {
   font: string;
 };
 
-export type TooltipRenderProps = RACTooltipRenderProps & {
+export type TooltipRenderProps = RacTooltipRenderProps & {
   /**
    * If the tooltip is visible
    */
@@ -56,7 +56,7 @@ type BaseTooltipTargetProps = BaseProps & {
 
 export type TooltipState = Omit<TooltipRenderProps, 'state'> &
   Required<
-    Pick<RACTooltipProps, 'containerPadding' | 'crossOffset' | 'offset'>
+    Pick<RacTooltipProps, 'containerPadding' | 'crossOffset' | 'offset'>
   >;
 
 export type TooltipTargetState = Required<
@@ -64,7 +64,7 @@ export type TooltipTargetState = Required<
 >;
 
 export type TooltipProps = Omit<
-  RACTooltipProps,
+  RacTooltipProps,
   'children' | 'className' | 'style' | 'UNSTABLE_portalContainer'
 > &
   BaseTooltipProps;


### PR DESCRIPTION
Closes no issue.

@orteth01 discovered an issue with the type of renderProps for the Tooltip component where it was expecting the wrong type of child. We discovered that we needed to omit the children prop from `react-aria-component` so that it would not occlude our own type, that has an addition `isOpen` property. This also allows for Typescript to correctly infer the type for the renderProps.

![CleanShot 2025-02-28 at 10 23 56@2x](https://github.com/user-attachments/assets/cff427d3-441f-49a4-aeac-e8566380b5d4)


## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

If you run the Tooltip Ladle story and use the renderProp pattern, there should be no Typescript errors.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

