### PR TITLE
readable classnames in ladle

### DIFF
--- a/packages/design-system/vite.config.js
+++ b/packages/design-system/vite.config.js
@@ -1,5 +1,17 @@
+/*
+ * Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 
 export default {
-  plugins: [vanillaExtractPlugin()],
+  plugins: [vanillaExtractPlugin({ identifiers: 'debug' })],
 };


### PR DESCRIPTION
in production ladle, the classnames are hashed and not very useful. 

OLD: 
![Screenshot 2025-03-12 at 6 09 19 PM](https://github.com/user-attachments/assets/d95ea300-16a4-4990-a1c2-076c64055578)

NEW:
![Screenshot 2025-03-12 at 6 10 36 PM](https://github.com/user-attachments/assets/5619490f-cfae-4678-8e6d-d4ea61e7eeb2)


## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

- run `pnpm --filter=@accelint/design-system exec ladle build`
  - this is the command used to generate the ladel docs in our gh-pages workflow
- look at the output in design-system/build/assets. verify that the classnames are useful 

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## 💬 Other information

- the classnames are fine when running ladle locally. unreadable classnames are only an issue when we build it 
