### PR TITLE
fix: select popover states

### DIFF
--- a/.changeset/eight-suns-type.md
+++ b/.changeset/eight-suns-type.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-system": patch
+---
+
+OptionList enable popover behavior

--- a/packages/design-system/src/components/menu/menu.css.ts
+++ b/packages/design-system/src/components/menu/menu.css.ts
@@ -136,7 +136,7 @@ export const menuClassNames: MenuClassNames = {
       '@layer': {
         [layers.components.l1]: {
           containerName: menuContainers.list,
-          display: 'contents',
+          display: 'block',
         },
       },
     }),

--- a/packages/design-system/src/components/options/options.css.ts
+++ b/packages/design-system/src/components/options/options.css.ts
@@ -141,7 +141,7 @@ export const optionsClassNames: OptionsClassNames = {
       '@layer': {
         [layers.components.l1]: {
           containerName: optionsContainers.list,
-          display: 'contents',
+          display: 'block',
         },
       },
     }),


### PR DESCRIPTION
Closes #239 

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues/239).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

1. Add a large div on top of any story in packages/design-system/src/components/select/select.stories.tsx.
2. run `pnpm --filter=@accelint/design-system preview`
3. change window so select input will be on bottom of page
4. select dropdown should appropriately position itself on top if there is no space on bottom

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

