### PR TITLE
Fix/update peer deps

### DIFF
--- a/.changeset/shy-toes-clap.md
+++ b/.changeset/shy-toes-clap.md
@@ -1,0 +1,14 @@
+<!-- Copyright 2025 Hypergiant Galactic Systems Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+---
+"@accelint/design-system": minor
+---
+
+allow react 19 as a valid peer dependency

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
     "@accelint/temporal": "workspace:*",
     "@accelint/typescript-config": "workspace:*",
     "@biomejs/biome": "1.9.3",
-    "@codesandbox/sandpack-react": "2.19.10",
+    "@codesandbox/sandpack-react": "2.20.0",
     "@docusaurus/core": "3.7.0",
     "@docusaurus/module-type-aliases": "3.7.0",
     "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "packageManager": "pnpm@9.12.1",
   "pnpm": {
     "overrides": {
-      "@react-types/shared": "3.25.0"
+      "@react-types/shared": "3.25.0",
+      "@docusaurus/plugin-debug@3.7.0>react-json-view-lite": "^2.0.0"
     }
   }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -53,9 +53,9 @@
     "@react-stately/overlays": "3.6.11",
     "@react-stately/utils": "3.10.4",
     "@react-types/shared": "3.25.0",
-    "react": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
     "react-aria-components": "1.4.1",
-    "react-dom": "^18.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-querybuilder": "7.7.0"
   },
   "devDependencies": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -53,9 +53,9 @@
     "@react-stately/overlays": "3.6.11",
     "@react-stately/utils": "3.10.4",
     "@react-types/shared": "3.25.0",
-    "react": "^18.0.0 || ^19.0.0",
+    "react": ">= ^18.0.0",
     "react-aria-components": "1.4.1",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react-dom": ">= ^18.0.0",
     "react-querybuilder": "7.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@react-types/shared': 3.25.0
+  '@docusaurus/plugin-debug@3.7.0>react-json-view-lite': ^2.0.0
 
 importers:
 
@@ -93,8 +94,8 @@ importers:
         specifier: 1.9.3
         version: 1.9.3
       '@codesandbox/sandpack-react':
-        specifier: 2.19.10
-        version: 2.19.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.20.0
+        version: 2.20.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@docusaurus/core':
         specifier: 3.7.0
         version: 3.7.0(@mdx-js/react@3.0.0(@types/react@18.3.11)(react@19.0.0))(@swc/core@1.7.36(@swc/helpers@0.5.15))(acorn@8.14.1)(debug@4.4.0)(esbuild@0.25.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.6.2)
@@ -349,13 +350,13 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       react:
-        specifier: ^18.0.0
+        specifier: '>= ^18.0.0'
         version: 18.3.1
       react-aria-components:
         specifier: 1.4.1
         version: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
-        specifier: ^18.0.0
+        specifier: '>= ^18.0.0'
         version: 18.3.1(react@18.3.1)
       react-querybuilder:
         specifier: 7.7.0
@@ -1462,11 +1463,11 @@ packages:
   '@codesandbox/sandpack-client@2.19.8':
     resolution: {integrity: sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==}
 
-  '@codesandbox/sandpack-react@2.19.10':
-    resolution: {integrity: sha512-X/7NzhR7R5pp5qYS+Gc31OzJvy+EzGz++H1YN9bJlDE+VzxTBsMN9dv3adzeo5wtxUhqexVOJS7mGr//e7KP2A==}
+  '@codesandbox/sandpack-react@2.20.0':
+    resolution: {integrity: sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
-      react-dom: ^16.8.0 || ^17 || ^18
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -7975,11 +7976,11 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-json-view-lite@1.5.0:
-    resolution: {integrity: sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==}
-    engines: {node: '>=14'}
+  react-json-view-lite@2.4.1:
+    resolution: {integrity: sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react: ^18.0.0 || ^19.0.0
 
   react-live@4.1.8:
     resolution: {integrity: sha512-B2SgNqwPuS2ekqj4lcxi5TibEcjWkdVyYykBEUBshPAPDQ527x2zPEZg560n8egNtAjUpwXFQm7pcXV65aAYmg==}
@@ -10600,7 +10601,7 @@ snapshots:
 
   '@codesandbox/nodebox@0.1.8':
     dependencies:
-      outvariant: 1.4.0
+      outvariant: 1.4.3
       strict-event-emitter: 0.4.6
 
   '@codesandbox/sandpack-client@2.19.8':
@@ -10612,7 +10613,7 @@ snapshots:
       outvariant: 1.4.0
       static-browser-server: 1.0.3
 
-  '@codesandbox/sandpack-react@2.19.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@codesandbox/sandpack-react@2.20.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.0
@@ -11242,7 +11243,7 @@ snapshots:
       fs-extra: 11.3.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      react-json-view-lite: 1.5.0(react@19.0.0)
+      react-json-view-lite: 2.4.1(react@19.0.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -18957,7 +18958,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-json-view-lite@1.5.0(react@19.0.0):
+  react-json-view-lite@2.4.1(react@19.0.0):
     dependencies:
       react: 19.0.0
 
@@ -19749,7 +19750,7 @@ snapshots:
       '@open-draft/deferred-promise': 2.2.0
       dotenv: 16.4.7
       mime-db: 1.53.0
-      outvariant: 1.4.0
+      outvariant: 1.4.3
 
   statuses@1.5.0: {}
 


### PR DESCRIPTION
Closes no issue.

When attempting to upgrade the design system in an app running react 19 there are peer dependency conflicts: 
![image](https://github.com/user-attachments/assets/fe6fd0e7-11c9-45fa-848d-6a58353b1450)


## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

This can only be tested locally until the library is included in artifactory, but including react 19 means there are no peer dependency conflict warnings when an app is running react 19.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

