### PR TITLE
build: change to simple doc build

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.8",
   "private": true,
   "scripts": {
-    "build": "pnpm run build:typedoc && pnpm run build:docusaurus",
+    "docs": "pnpm run build:typedoc && pnpm run build:docusaurus",
     "build:docusaurus": "docusaurus build",
     "build:contributing": "mv ./content/api/_media/CONTRIBUTING.md ./content/CONTRIBUTING.md",
     "build:license": "mv ./content/api/_media/LICENSE ./content/LICENSE.md",
     "build:typedoc": "typedoc && pnpm run build:contributing && pnpm run build:license",
     "clear": "docusaurus clear",
-    "dev": "pnpm run build && docusaurus start",
+    "dev": "pnpm run docs && docusaurus start",
     "serve": "docusaurus serve"
   },
   "dependencies": {
@@ -53,6 +53,6 @@
     ]
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "deps:version-minor": "pnpm taze minor -r",
     "deps:version-patch": "pnpm taze patch -r",
     "dev": "turbo dev",
+    "docs": "turbo docs",
     "format": "pnpm biome format . --write",
     "indexer": "turbo index",
     "license": "pnpm zx scripts/license.mjs",

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,10 @@
     "build": {
       "dependsOn": ["index", "^build"],
       "outputs": ["dist", "build"]
+    },
+    "docs": {
+      "dependsOn": ["^index"],
+      "outputs": ["build"]
     }
   }
 }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## 💬 Other information

Added a `doc` command that just depends on upstream index files for use in generating the doc site.