### PR TITLE
fix: remove unneeded exports for menu.item.icon and menu.item.keyboard

### DIFF
--- a/.changeset/popular-actors-grab.md
+++ b/.changeset/popular-actors-grab.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Remove menu icon and menu keyboard exports

--- a/design-toolkit/components/src/components/menu/index.tsx
+++ b/design-toolkit/components/src/components/menu/index.tsx
@@ -104,7 +104,12 @@ export const MenuItem = (props: MenuItemProps) => {
     (isSlottedContextValue(context) ? undefined : context?.variant) ??
     MenuStylesDefaults.variant;
 
-  const { classNames, color = MenuStylesDefaults.color, children, ...rest } = props;
+  const {
+    classNames,
+    color = MenuStylesDefaults.color,
+    children,
+    ...rest
+  } = props;
 
   return (
     <AriaMenuItem

--- a/design-toolkit/components/src/components/menu/menu.stories.tsx
+++ b/design-toolkit/components/src/components/menu/menu.stories.tsx
@@ -14,11 +14,11 @@ import Kebab from '@accelint/icons/kebab';
 import Placeholder from '@accelint/icons/placeholder';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ReactNode } from 'react';
+import { Keyboard } from 'react-aria-components';
 import { Button } from '../button';
 import { Icon } from '../icon';
 import { Menu } from './';
 import type { MenuItemProps } from './types';
-import { Keyboard } from 'react-aria-components';
 
 const meta: Meta<typeof Menu> = {
   title: 'Components/Menu',

--- a/design-toolkit/components/src/index.ts
+++ b/design-toolkit/components/src/index.ts
@@ -135,8 +135,6 @@ export {
   MenuContext,
   MenuDescription,
   MenuItem,
-  MenuItemIcon,
-  MenuItemKeyboard,
   MenuLabel,
   MenuSection,
   MenuSeparator,
@@ -144,9 +142,7 @@ export {
 export { MenuStyles, MenuStylesDefaults } from './components/menu/styles';
 export type { MenuStyleVariants } from './components/menu/styles';
 export type {
-  MenuIconProps,
   MenuItemProps,
-  MenuKeyboardProps,
   MenuProps,
   MenuSectionProps,
   MenuTextProps,


### PR DESCRIPTION
Closes no issue.

In prep for release, just making sure the exports are accurate, plus a microscopic amount of formatting.

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

Should be a no-op.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

