### PR TITLE
fix: add default text-color to filled buttons so they retain design schema

### DIFF
--- a/.changeset/soft-shrimps-retire.md
+++ b/.changeset/soft-shrimps-retire.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Added default text color for filled buttons

--- a/design-toolkit/components/src/components/button/styles.ts
+++ b/design-toolkit/components/src/components/button/styles.ts
@@ -54,6 +54,7 @@ const BaseButtonStyles = tv({
       color: 'info',
       variant: 'filled',
       className: [
+        'enabled:fg-inverse-light',
         'enabled:bg-interactive-default',
         'enabled:hover:bg-interactive-hover-light',
         'enabled:focus:bg-interactive-hover-light',
@@ -92,6 +93,7 @@ const BaseButtonStyles = tv({
       color: 'serious',
       variant: 'filled',
       className: [
+        'enabled:fg-inverse-light',
         'enabled:bg-serious',
         'enabled:hover:bg-serious-hover',
         'enabled:focus:bg-serious-hover',
@@ -130,6 +132,7 @@ const BaseButtonStyles = tv({
       color: 'critical',
       variant: 'filled',
       className: [
+        'enabled:fg-default-light',
         'enabled:bg-critical',
         'enabled:hover:bg-critical-hover',
         'enabled:focus:bg-critical-hover',
@@ -181,6 +184,7 @@ export const ToggleButtonStyles = tv({
       color: 'info',
       variant: 'filled',
       className: [
+        'enabled:fg-inverse-light',
         'enabled:selected:bg-info-subtle',
         'enabled:selected:hover:bg-interactive-hover-light',
         'enabled:selected:focus:bg-interactive-hover-light',
@@ -199,6 +203,7 @@ export const ToggleButtonStyles = tv({
       color: 'serious',
       variant: 'filled',
       className: [
+        'enabled:fg-inverse-light',
         'enabled:selected:bg-serious-subtle',
         'enabled:selected:hover:bg-serious-hover',
         'enabled:selected:focus:bg-serious-hover',
@@ -217,6 +222,7 @@ export const ToggleButtonStyles = tv({
       color: 'critical',
       variant: 'filled',
       className: [
+        'enabled:fg-default-light',
         'enabled:selected:bg-critical-subtle',
         'enabled:selected:hover:bg-critical-hover',
         'enabled:selected:focus:bg-critical-hover',


### PR DESCRIPTION

Closes [PATH-593](https://gohypergiant.atlassian.net/browse/PATH-593)

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

- open the design-toolkit preview from `main`
- click `Dialog` and click the "press me" button
- notice that the Action 1 button text is now the correct color vs the same color as the dialog body text
- click 'Button' and play with the 'color' variations for the default and toggle buttons. Notice the text is still the correct color

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

### Before

https://github.com/user-attachments/assets/c35bb739-6dbf-444c-9c7f-eba9a1218ce1

### After 

https://github.com/user-attachments/assets/0b117089-3fa0-41b9-a99d-92698b86f0cd