### PR TITLE
build: add subpath exports to packages

### DIFF
--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -30,6 +30,13 @@
         "default": "./dist/vanilla.js"
       },
       "default": "./dist/vanilla.js"
+    },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
     }
   },
   "scripts": {

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/predicates/package.json
+++ b/packages/predicates/package.json
@@ -18,6 +18,13 @@
       },
       "default": "./dist/index.js"
     },
+    "./*": {
+      "import": {
+        "types": "./dist/*/index.d.ts",
+        "default": "./dist/*/index.js"
+      },
+      "default": "./dist/*/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Enables importing individual files from package for environments without treeshaking or a bundler
## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

