### PR TITLE
Fix/textfield input type

### DIFF
--- a/.changeset/silly-humans-travel.md
+++ b/.changeset/silly-humans-travel.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+remove duplicative type prop from TextField

--- a/design-toolkit/components/src/components/text-field/types.ts
+++ b/design-toolkit/components/src/components/text-field/types.ts
@@ -20,7 +20,7 @@ import type { LabelProps } from '../label/types';
 
 export type TextFieldProps = Omit<
   AriaTextFieldProps,
-  'children' | 'className'
+  'children' | 'className' | 'type'
 > &
   RefAttributes<HTMLDivElement> & {
     classNames?: {


### PR DESCRIPTION
Closes no ticket.

When working with the TextField component, in order to designate it as a 'password' type, you use the `inputProps` object:

<img width="802" height="550" alt="CleanShot 2025-07-29 at 09 31 27@2x" src="https://github.com/user-attachments/assets/6c53cb21-9126-41b7-b015-4b2f38e04245" />

But it was confusing initially because there is also a prop on the RAC TextField for `type` that we are ignoring in our implementation, so I am adding it to the `Omit` utility type here to reduce confusion.

<img width="1480" height="608" alt="CleanShot 2025-07-29 at 09 32 22@2x" src="https://github.com/user-attachments/assets/efe3246b-3e12-4776-87eb-e87a092dc993" />


## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

