### PR TITLE
fix: added labelPosition prop to Switch

### DIFF
--- a/.changeset/hungry-planes-smell.md
+++ b/.changeset/hungry-planes-smell.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+added labelPosition prop to Switch component

--- a/design-toolkit/components/src/components/switch/index.tsx
+++ b/design-toolkit/components/src/components/switch/index.tsx
@@ -75,7 +75,7 @@ SwitchProvider.displayName = 'Switch.Provider';
 export function Switch({ ref, ...props }: SwitchProps) {
   [props, ref] = useContextProps(props, ref ?? null, SwitchContext);
 
-  const { children, classNames, ...rest } = props;
+  const { children, classNames, labelPosition = 'end', ...rest } = props;
 
   return (
     <AriaSwitch
@@ -87,8 +87,13 @@ export function Switch({ ref, ...props }: SwitchProps) {
     >
       {composeRenderProps(children, (children) => (
         <>
+          {children && labelPosition === 'start' && (
+            <span className={label({ className: classNames?.label })}>
+              {children}
+            </span>
+          )}
           <span className={control({ className: classNames?.control })} />
-          {children && (
+          {children && labelPosition === 'end' && (
             <span className={label({ className: classNames?.label })}>
               {children}
             </span>

--- a/design-toolkit/components/src/components/switch/index.tsx
+++ b/design-toolkit/components/src/components/switch/index.tsx
@@ -82,18 +82,13 @@ export function Switch({ ref, ...props }: SwitchProps) {
       {...rest}
       ref={ref}
       className={composeRenderProps(classNames?.switch, (className) =>
-        switchClassNames({ className }),
+        switchClassNames({ className, labelPosition }),
       )}
     >
       {composeRenderProps(children, (children) => (
         <>
-          {children && labelPosition === 'start' && (
-            <span className={label({ className: classNames?.label })}>
-              {children}
-            </span>
-          )}
           <span className={control({ className: classNames?.control })} />
-          {children && labelPosition === 'end' && (
+          {children && (
             <span className={label({ className: classNames?.label })}>
               {children}
             </span>

--- a/design-toolkit/components/src/components/switch/styles.ts
+++ b/design-toolkit/components/src/components/switch/styles.ts
@@ -30,4 +30,14 @@ export const SwitchStyles = tv({
       'group-disabled/switch:text-interactive-disabled',
     ],
   },
+  variants: {
+    labelPosition: {
+      start: {
+        switch: 'flex-row-reverse',
+      },
+      end: {
+        switch: 'flex-row',
+      },
+    },
+  },
 });

--- a/design-toolkit/components/src/components/switch/switch.stories.tsx
+++ b/design-toolkit/components/src/components/switch/switch.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<typeof Switch> = {
   args: {
     children: 'Label',
     isDisabled: false,
+    labelPosition: 'end',
   },
 };
 

--- a/design-toolkit/components/src/components/switch/types.ts
+++ b/design-toolkit/components/src/components/switch/types.ts
@@ -20,4 +20,5 @@ export type SwitchProps = Omit<AriaSwitchProps, 'className'> &
       control?: string;
       label?: string;
     };
+    labelPosition?: 'start' | 'end';
   };


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

Run Storybook via `pnpm --filter=@accelint/design-toolkit run preview`, toggle labelPosition prop

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

