### PR TITLE
Fix/combobox styles

### DIFF
--- a/.changeset/pink-socks-sip.md
+++ b/.changeset/pink-socks-sip.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fixed Combobox styles

--- a/design-toolkit/components/src/components/combobox-field/styles.ts
+++ b/design-toolkit/components/src/components/combobox-field/styles.ts
@@ -18,7 +18,9 @@ export const ComboBoxStyles = tv({
     label: '',
     control: [
       'flex items-center rounded-medium px-s py-xs outline',
-      'group-enabled/combobox-field:fg-default-light group-enabled:combobox-field:outline-interactive',
+      'group-size-medium/combobox-field:min-w-[160px] group-size-medium/combobox-field:max-w-[400px]',
+      'group-size-small/combobox-field:min-w-[80px] group-size-small/combobox-field:max-w-[200px]',
+      'group-enabled/combobox-field:fg-default-light group-enabled/combobox-field:outline-interactive',
       'group-enabled/combobox-field:placeholder:fg-default-dark',
       'group-enabled/combobox-field:focus-within:outline-highlight',
       'group-enabled/combobox-field:hover:outline-interactive-hover',
@@ -26,7 +28,7 @@ export const ComboBoxStyles = tv({
       'group-disabled/combobox-field:fg-disabled group-disabled/combobox-field:outline-interactive-disabled',
     ],
     input: [
-      'font-display outline-none',
+      'grow font-display outline-none',
       'group-size-medium/combobox-field:text-body-s',
       'group-size-small/combobox-field:text-body-xs',
     ],

--- a/design-toolkit/components/src/components/input/styles.ts
+++ b/design-toolkit/components/src/components/input/styles.ts
@@ -102,7 +102,7 @@ export const InputStyles = tv({
       className: {
         sizer: [
           'group-size-medium/input:min-w-[160px] group-size-medium/input:max-w-[400px]',
-          'group-size-medium/input:min-w-[80px] group-size-small/input:max-w-[200px]',
+          'group-size-small/input:min-w-[80px] group-size-small/input:max-w-[200px]',
         ],
       },
     },


### PR DESCRIPTION
Closes https://gohypergiant.atlassian.net/browse/CORE-4 <!-- Github issue # here -->

## ✅ Pull Request Checklist:
- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

Open Combobox in Storybook, notice two fixes:
- Outline style is not hover state at rest
- Input grows to fill container (with min & max)

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

