### PR TITLE
fix: build, min pnpm 10 -> 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "bugs": "https://github.com/gohypergiant/standard-toolkit/issues",
   "engines": {
     "node": ">=18",
-    "pnpm": ">=10"
+    "pnpm": ">=9"
   },
   "packageManager": "pnpm@10.9.0",
   "pnpm": {


### PR DESCRIPTION
Partial Revert "build: on clean, remove coverage folders and tsconfig.tsbuildinfo files"
This reverts commit 8ddcd0e9418a33c1029195183f17464a53dbb64a.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:
- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information

