### PR TITLE
fix: bring tabs up to date with required structure

### DIFF
--- a/apps/next/src/app/kitchen-sink/page.tsx
+++ b/apps/next/src/app/kitchen-sink/page.tsx
@@ -189,6 +189,9 @@ export default function KitchenSink() {
                   Tab 3
                 </Tabs.List.Tab>
               </Tabs.List>
+              <Tabs.Panel id='uno'>Content 1</Tabs.Panel>
+              <Tabs.Panel id='dos'>Content 2</Tabs.Panel>
+              <Tabs.Panel id='tres'>Content 3</Tabs.Panel>
             </Tabs>
             {divider}
             <Tabs orientation='vertical'>
@@ -199,6 +202,9 @@ export default function KitchenSink() {
                   Tab 3
                 </Tabs.List.Tab>
               </Tabs.List>
+              <Tabs.Panel id='uno'>Content 1</Tabs.Panel>
+              <Tabs.Panel id='dos'>Content 2</Tabs.Panel>
+              <Tabs.Panel id='tres'>Content 3</Tabs.Panel>
             </Tabs>
           </div>
           <div>


### PR DESCRIPTION
Closes no issue.

Small PR to make sure the kitchen sink page in the example app isn't throwing errors. Not adding a changeset since it shouldn't really be a version bump on this one.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

You can run the example app locally with `pnpm --filter '*apps/next' run dev` and make sure that all the pages load.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
