### PR TITLE
Fix: SelectField doesn't support isReadOnly

### DIFF
--- a/.changeset/cyan-pets-yell.md
+++ b/.changeset/cyan-pets-yell.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": minor
+---
+
+Removed non-functional `isReadOnly` prop from `SelectField`

--- a/design-toolkit/components/src/components/date-field/date-field.docs.mdx
+++ b/design-toolkit/components/src/components/date-field/date-field.docs.mdx
@@ -35,7 +35,6 @@ A form input component for entering and editing date and time values. The DateFi
 - **`placeholder`** - Placeholder text shown when no value is entered
 - **`isRequired`** - Whether the field is required (adds required indicator to label)
 - **`isDisabled`** - Whether the field is disabled
-- **`isReadOnly`** - Whether the field is read-only
 - **`isInvalid`** - Whether to show the field in an invalid state
 
 ### Size & Appearance

--- a/design-toolkit/components/src/components/select-field/select-field.docs.mdx
+++ b/design-toolkit/components/src/components/select-field/select-field.docs.mdx
@@ -52,19 +52,19 @@ The size can be controlled via the `size` prop or set globally using the `Select
 
 <Canvas of={SelectFieldStories.Default} />
 
-## Props
+## Controlled Selection
+Setting a selected option is supported via the `selectedKey` and `onSelectionChange` prop. The selected key corresponds to the id prop of an item, so note that the items in your option list must have an `id` property. When Select is used with a dynamic collection (an `items` prop on `Options`), the id of each item is derived from the data.
+<Canvas of={SelectFieldStories.ControlledSelection} />
 
+## Props
+All the props from the `Select` headless component are available in the `SelectField` component (except `className` which is expanded to `classNames`). [Details can be found in the docs](https://react-spectrum.adobe.com/react-aria/Select.html#props).
+
+There are additional props that are specific to our implementation of `SelectField`:
 * **`label`** - Text label displayed above the select field
 * **`description`** - Helper text displayed below the select field
 * **`errorMessage`** - Error text displayed when validation fails
 * **`size`** - Size variant: `'medium'` (default) or `'small'`
-* **`placeholder`** - Placeholder text displayed when no option is selected
-* **`isDisabled`** - Disables the select field
-* **`isRequired`** - Marks the select field as required
-* **`isInvalid`** - Marks the select field as invalid
-* **`isReadOnly`** - Makes the select field read-only
-* **`autoFocus`** - Automatically focuses the select field on mount
-* **`layoutOptions`** - Configuration for virtualized rendering of large option lists
+* **`layoutOptions`** - Configuration for virtualized rendering of large option lists ([more details here](https://react-spectrum.adobe.com/react-aria/Virtualizer.html#listlayout))
 * **`classNames`** - Custom class names for styling:
   * `field` - Applied to the select field container
   * `label` - Applied to the label element

--- a/design-toolkit/components/src/components/select-field/select-field.stories.tsx
+++ b/design-toolkit/components/src/components/select-field/select-field.stories.tsx
@@ -11,11 +11,12 @@
  */
 
 import Placeholder from '@accelint/icons/placeholder';
+import { type ReactNode, useId, useState } from 'react';
 import { Icon } from '../icon';
 import { Options } from '../options';
 import { SelectField } from './index';
+import type { Key } from '@react-types/shared';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { ReactNode } from 'react';
 
 const meta: Meta<typeof SelectField> = {
   title: 'Components/SelectField',
@@ -88,6 +89,55 @@ export const Default: StoryObj<typeof SelectField> = {
             <Options.Item.Label>Hornbill</Options.Item.Label>
           </Options.Item>
         </Options.Section>
+      </SelectField>
+    );
+  },
+};
+
+export const ControlledSelection: StoryObj<typeof SelectField> = {
+  render: (args) => {
+    const koalaId = useId();
+    const kangarooId = useId();
+    const platypusId = useId();
+    const bisonId = useId();
+    const [value, setValue] = useState<Key>(bisonId);
+
+    const handleSelection = (key: Key | null) => {
+      if (key) {
+        setValue(key);
+      }
+    };
+
+    return (
+      <SelectField
+        {...args}
+        selectedKey={value}
+        onSelectionChange={handleSelection}
+      >
+        <Options.Item id={koalaId} textValue='Koala'>
+          <Icon>
+            <Placeholder />
+          </Icon>
+          <Options.Item.Label>Koala</Options.Item.Label>
+        </Options.Item>
+        <Options.Item id={kangarooId} textValue='Kangaroo'>
+          <Icon>
+            <Placeholder />
+          </Icon>
+          <Options.Item.Label>Kangaroo</Options.Item.Label>
+        </Options.Item>
+        <Options.Item id={platypusId} textValue='Platypus'>
+          <Icon>
+            <Placeholder />
+          </Icon>
+          <Options.Item.Label>Platypus</Options.Item.Label>
+        </Options.Item>
+        <Options.Item id={bisonId} textValue='Bison'>
+          <Icon>
+            <Placeholder />
+          </Icon>
+          <Options.Item.Label>Bison</Options.Item.Label>
+        </Options.Item>
       </SelectField>
     );
   },

--- a/design-toolkit/components/src/components/select-field/types.ts
+++ b/design-toolkit/components/src/components/select-field/types.ts
@@ -36,5 +36,4 @@ export type SelectFieldProps = Omit<AriaSelectProps, 'className'> &
     description?: string;
     errorMessage?: string;
     size?: 'medium' | 'small';
-    isReadOnly?: boolean;
   };

--- a/design-toolkit/components/src/components/switch/switch.docs.mdx
+++ b/design-toolkit/components/src/components/switch/switch.docs.mdx
@@ -60,7 +60,6 @@ The Switch component has a single visual variant that automatically adapts based
 * **`defaultSelected`** - Initial selected state
 * **`onSelectionChange`** - Callback when selection changes
 * **`isDisabled`** - Disables the switch
-* **`isReadOnly`** - Makes the switch read-only
 * **`autoFocus`** - Automatically focuses the switch on mount
 * **`classNames`** - Custom class names for styling:
   * `switch` - Applied to the switch container


### PR DESCRIPTION
Closes [PATH-752](https://gohypergiant.atlassian.net/browse/PATH-752)

This came in from the support portal. We removed the state of "read only" from our component system (for now) while there is additional work done around design and usability.

This also adds an additional story to SelectField that demonstrates its use as a controlled component, which was identified as a hole in our documentation.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
