### PR TITLE
Feat: add audience and individual targeting to bus

### DIFF
--- a/.changeset/seven-hounds-build.md
+++ b/.changeset/seven-hounds-build.md
@@ -2,4 +2,4 @@
 "@accelint/bus": minor
 ---
 
-Add echo option to emit so that one can opt out of self-delivered messages, defaults to true.
+Update event bus to target audiences such as 'all', 'others', 'self'. As well as individual contexts via a uuid.

--- a/.changeset/seven-hounds-build.md
+++ b/.changeset/seven-hounds-build.md
@@ -1,0 +1,5 @@
+---
+"@accelint/bus": minor
+---
+
+Add echo option to emit so that one can opt out of self-delivered messages, defaults to true.

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -39,6 +39,7 @@
     "test:watch": "pnpm vitest --dir=src --watch"
   },
   "devDependencies": {
+    "@accelint/core": "workspace:*",
     "@accelint/typescript-config": "workspace:*",
     "@accelint/vitest-config": "workspace:*",
     "@testing-library/dom": "^10.4.1",
@@ -48,11 +49,12 @@
     "esbuild-fix-imports-plugin": "1.0.21",
     "react": "^19.0.0",
     "tsup": "8.5.0",
+    "typescript": "^5.8.3",
     "vitest": "2.1.3",
     "vitest-broadcast-channel-mock": "0.1.0"
   },
-  "dependencies": {
-    "@accelint/core": "workspace:*",
+  "peerDependencies": {
+    "@accelint/core": "^0.4.1",
     "typescript": "^5.8.3"
   },
   "optionalDependencies": {

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -52,6 +52,7 @@
     "vitest-broadcast-channel-mock": "0.1.0"
   },
   "dependencies": {
+    "@accelint/core": "workspace:*",
     "typescript": "^5.8.3"
   },
   "optionalDependencies": {

--- a/packages/bus/src/broadcast/index.test.ts
+++ b/packages/bus/src/broadcast/index.test.ts
@@ -43,7 +43,6 @@ describe('broadcast', () => {
       payload: 'test',
       type: 'test',
     });
-    expect(bus.getEvents()).toContain('test');
   });
 
   it('once', () => {
@@ -60,7 +59,6 @@ describe('broadcast', () => {
       payload: 'test',
       type: 'test',
     });
-    expect(bus.getEvents()).not.toContain('test');
   });
 
   it('on & once', () => {
@@ -94,8 +92,6 @@ describe('broadcast', () => {
       payload: 'A',
       type: 'test',
     });
-
-    expect(bus.getEvents()).toContain('test');
   });
 
   it('off', () => {
@@ -107,7 +103,6 @@ describe('broadcast', () => {
     bus.emit('test', 'test');
 
     expect(fn).not.toHaveBeenCalled();
-    expect(bus.getEvents()).toContain('test');
   });
 
   it('destroy', () => {
@@ -119,7 +114,6 @@ describe('broadcast', () => {
     bus.emit('test', 'test');
 
     expect(fn).not.toHaveBeenCalled();
-    expect(bus.getEvents()).toEqual([]);
   });
 
   it('should deliver to all', () => {

--- a/packages/bus/src/broadcast/index.test.ts
+++ b/packages/bus/src/broadcast/index.test.ts
@@ -31,7 +31,7 @@ describe('broadcast', () => {
     const fn = vi.fn();
 
     bus.on('test', fn);
-    bus.emit('test', 'test');
+    bus.emit('test', 'test', { echo: true });
 
     expect(fn).toHaveBeenCalled();
     expect(fn).toHaveBeenCalledWith({
@@ -80,5 +80,26 @@ describe('broadcast', () => {
 
     expect(fn).not.toHaveBeenCalled();
     expect(bus.getEvents()).toEqual([]);
+  });
+
+  it('should echo to itself', () => {
+    const bus = Broadcast.getInstance();
+    const fn = vi.fn();
+
+    bus.on('test', fn);
+    bus.emit('test', 'echo');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith({ type: 'test', payload: 'echo' });
+  });
+
+  it('should not echo to itself', () => {
+    const bus = Broadcast.getInstance();
+    const fn = vi.fn();
+
+    bus.on('test', fn);
+    bus.emit('test', 'test', { echo: false });
+
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/packages/bus/src/broadcast/index.test.ts
+++ b/packages/bus/src/broadcast/index.test.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { uuid } from '@accelint/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mockBroadcastChannel,
@@ -82,24 +83,65 @@ describe('broadcast', () => {
     expect(bus.getEvents()).toEqual([]);
   });
 
-  it('should echo to itself', () => {
+  it('should deliver to self', () => {
     const bus = Broadcast.getInstance();
     const fn = vi.fn();
 
     bus.on('test', fn);
-    bus.emit('test', 'echo');
+    bus.emit('test', 'self', { target: 'self' });
 
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(fn).toHaveBeenCalledWith({ type: 'test', payload: 'echo' });
+    expect(fn).toHaveBeenCalledWith({ type: 'test', payload: 'self' });
   });
 
-  it('should not echo to itself', () => {
+  it('should deliver to others', () => {
     const bus = Broadcast.getInstance();
     const fn = vi.fn();
 
     bus.on('test', fn);
-    bus.emit('test', 'test', { echo: false });
+    bus.emit('test', 'echo', { target: 'others' });
 
     expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('should deliver to all', () => {
+    const bus = Broadcast.getInstance();
+    const fn = vi.fn();
+
+    bus.on('test', fn);
+    bus.emit('test', 'all', { target: 'all' });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith({ type: 'test', payload: 'all' });
+  });
+
+  it('should default to all as target audience', () => {
+    const bus = Broadcast.getInstance();
+    const fn = vi.fn();
+
+    bus.on('test', fn);
+    bus.emit('test', 'default');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith({ type: 'test', payload: 'default' });
+  });
+
+  it('should deliver to specific target', () => {
+    const bus = Broadcast.getInstance();
+    const fn = vi.fn();
+
+    bus.on('test', fn);
+    bus.emit('test', 'test', { target: bus.uuid });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith({
+      type: 'test',
+      payload: 'test',
+      target: bus.uuid,
+    });
+
+    bus.emit('test', 'test', { target: uuid() });
+
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -146,7 +146,7 @@ export class Broadcast<
     this.listeners[type].push(listener);
   }
 
-  setEventEmitOptions(type: P['type'], options?: EmitOptions) {
+  setEventEmitOptions(type: P['type'], options: EmitOptions | null) {
     if (options) {
       this.emitOptions.set(type, options);
     } else {
@@ -154,13 +154,13 @@ export class Broadcast<
     }
   }
 
-  setEventsEmitOptions(events: Map<P['type'], EmitOptions | undefined>) {
+  setEventsEmitOptions(events: Map<P['type'], EmitOptions | null>) {
     for (const [type, options] of events) {
       this.setEventEmitOptions(type, options);
     }
   }
 
-  setGlobalEmitOptions(options?: EmitOptions) {
+  setGlobalEmitOptions(options: EmitOptions | null) {
     this.setEventEmitOptions(this.id, options);
   }
 

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -146,6 +146,14 @@ export class Broadcast<
     this.listeners[type].push(listener);
   }
 
+  /**
+   * Set emit options for event by type, options will apply to all emits of this event
+   *
+   * Keep in mind that options are merged: global, event, local (lowest to highest precendence)
+   *
+   * @param type event type
+   * @param options emit options
+   */
   setEventEmitOptions(type: P['type'], options: EmitOptions | null) {
     if (options) {
       this.emitOptions.set(type, options);
@@ -154,12 +162,22 @@ export class Broadcast<
     }
   }
 
+  /**
+   * Set a series of events emit options
+   *
+   * @param events map of event type & options
+   */
   setEventsEmitOptions(events: Map<P['type'], EmitOptions | null>) {
     for (const [type, options] of events) {
       this.setEventEmitOptions(type, options);
     }
   }
 
+  /**
+   * Set global emit options, the lowest precedence options, to be merged with event emit options and local options
+   *
+   * @param options emit options
+   */
   setGlobalEmitOptions(options: EmitOptions | null) {
     this.setEventEmitOptions(this.id, options);
   }

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -103,17 +103,9 @@ export class Broadcast<
     const handlers = this.listeners[data.type as P['type']];
 
     /**
-     * If no handler exists, do nothing.
+     * If no handler exists or if event targets a specific instance of Broadcast that isn't this instance, do nothing
      */
-    if (!handlers?.length) {
-      console.warn('No listeners registered for this event type:', data.type);
-      return;
-    }
-
-    /**
-     * If event targets a specific instance of Broadcast that isn't this instance, do nothing.
-     */
-    if (data.target && data.target !== this.id) {
+    if (!handlers?.length || (data.target && data.target !== this.id)) {
       return;
     }
 
@@ -292,7 +284,7 @@ export class Broadcast<
     }
 
     if (!this.channel.onmessage) {
-      console.warn('No message listener for this channel.');
+      console.warn('No listeners registered for this event type:', type);
       return;
     }
 

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -11,7 +11,13 @@
  */
 
 import { DEFAULT_CONFIG } from './constants';
-import type { BroadcastConfig, ExtractEvent, Listener, Payload } from './types';
+import type {
+  BroadcastConfig,
+  EmitOptions,
+  ExtractEvent,
+  Listener,
+  Payload,
+} from './types';
 
 /** Broadcast event class allows for emitting and listening for events */
 export class Broadcast<
@@ -187,6 +193,7 @@ export class Broadcast<
    * @template T - The Payload type, inferred from the event.
    * @param type - The event type.
    * @param payload - The event payload.
+   * @param options.echo - If true (default), also deliver to this context via channel.onmessage.
    *
    * @example
    * bus.emit(
@@ -205,12 +212,14 @@ export class Broadcast<
     payload: ExtractEvent<P, T> extends { payload: infer Data }
       ? Data
       : undefined,
+    options?: EmitOptions,
   ): void;
   emit<T extends P['type']>(
     type: T,
     payload?: ExtractEvent<P, T> extends { payload: infer Data }
       ? Data
       : undefined,
+    options?: EmitOptions,
   ) {
     if (!this.channel) {
       console.warn('Cannot emit: BroadcastChannel is not initialized.');
@@ -227,7 +236,9 @@ export class Broadcast<
     }
 
     // NOTE: this allows the context that emitted the event to also listen for it
-    this.channel.onmessage({ data: message } as MessageEvent<P>);
+    if (options?.echo ?? true) {
+      this.channel.onmessage({ data: message } as MessageEvent<P>);
+    }
   }
 
   /**

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -29,7 +29,7 @@ export class Broadcast<
   >,
 > {
   protected channel: BroadcastChannel | null = null;
-  protected channelName: string;
+  protected channelName = DEFAULT_CONFIG.channelName;
   protected listeners: Partial<Record<P['type'], Listener<P>[]>> = {};
   protected emitOptions: Map<P['type'], EmitOptions> = new Map();
 
@@ -40,7 +40,9 @@ export class Broadcast<
 
   /** Broadcast class constructor. */
   constructor(config?: BroadcastConfig) {
-    this.channelName = config?.channelName ?? DEFAULT_CONFIG.channelName;
+    if (config?.channelName) {
+      this.channelName = config.channelName;
+    }
 
     this.init();
   }
@@ -115,10 +117,6 @@ export class Broadcast<
       if (once) {
         this.removeListener(data.type, id);
       }
-    }
-
-    if (this.listeners[data.type as P['type']]?.length === 0) {
-      this.deleteEvent(data.type);
     }
   }
 
@@ -329,18 +327,12 @@ export class Broadcast<
     if (this.channel) {
       this.channel.close();
       this.channel = null;
+      this.channelName = DEFAULT_CONFIG.channelName;
     }
 
     this.listeners = {};
     this.emitOptions = new Map();
 
     Broadcast.instance = null;
-  }
-
-  /**
-   * Get a list of all available events.
-   */
-  getEvents(): P['type'][] {
-    return Object.keys(this.listeners);
   }
 }

--- a/packages/bus/src/broadcast/index.ts
+++ b/packages/bus/src/broadcast/index.ts
@@ -103,9 +103,17 @@ export class Broadcast<
     const handlers = this.listeners[data.type as P['type']];
 
     /**
-     * If no handler exists or if event targets a specific instance of Broadcast that isn't this instance, do nothing
+     * If no handler exists, do nothing.
      */
-    if (!handlers?.length || (data.target && data.target !== this.id)) {
+    if (!handlers?.length) {
+      console.warn('No listeners registered for this event type:', data.type);
+      return;
+    }
+
+    /**
+     * If event targets a specific instance of Broadcast that isn't this instance, do nothing.
+     */
+    if (data.target && data.target !== this.id) {
       return;
     }
 
@@ -284,7 +292,7 @@ export class Broadcast<
     }
 
     if (!this.channel.onmessage) {
-      console.warn('No listeners registered for this event type:', type);
+      console.warn('No message listener for this channel.');
       return;
     }
 

--- a/packages/bus/src/broadcast/types.ts
+++ b/packages/bus/src/broadcast/types.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { type UniqueId } from '@accelint/core';
+import type { UniqueId } from '@accelint/core';
 
 /** Broadcast configuration type. */
 export type BroadcastConfig = {
@@ -21,9 +21,9 @@ export type BroadcastConfig = {
 /** Listener object type. */
 export type Listener<P extends { type: string; payload?: unknown } = Payload> =
   {
-    callback: (data: P) => void;
+    id: UniqueId;
     once?: boolean;
-    id: number;
+    callback: (data: P) => void;
   };
 
 /** Listener callback payload type. */
@@ -50,5 +50,5 @@ export type ExtractEvent<
 }[T];
 
 export type EmitOptions = {
-  target: 'self' | 'others' | 'all' | UniqueId;
+  target?: 'all' | 'others' | 'self' | UniqueId;
 };

--- a/packages/bus/src/broadcast/types.ts
+++ b/packages/bus/src/broadcast/types.ts
@@ -44,3 +44,7 @@ export type ExtractEvent<
 > = {
   [K in P['type']]: Extract<P, { type: K }>;
 }[T];
+
+export type EmitOptions = {
+  echo: boolean;
+};

--- a/packages/bus/src/broadcast/types.ts
+++ b/packages/bus/src/broadcast/types.ts
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { type UniqueId } from '@accelint/core';
+
 /** Broadcast configuration type. */
 export type BroadcastConfig = {
   channelName: string;
@@ -31,9 +33,11 @@ export type Payload<
 > = P extends undefined
   ? {
       type: T;
+      target?: UniqueId;
     }
   : {
       type: T;
+      target?: UniqueId;
       payload: P;
     };
 
@@ -46,5 +50,5 @@ export type ExtractEvent<
 }[T];
 
 export type EmitOptions = {
-  echo: boolean;
+  target: 'self' | 'others' | 'all' | UniqueId;
 };

--- a/packages/bus/src/index.ts
+++ b/packages/bus/src/index.ts
@@ -19,6 +19,7 @@
 export { Broadcast } from './broadcast';
 export type {
   BroadcastConfig,
+  EmitOptions,
   ExtractEvent,
   Listener,
   Payload,

--- a/packages/bus/src/react/index.ts
+++ b/packages/bus/src/react/index.ts
@@ -19,6 +19,7 @@ import type { EmitOptions, ExtractEvent, Payload } from '../broadcast/types';
 /**
  * A convenience wrapper for useEmit & useOn, to pass down types instead of having
  * to reimplement generics each time
+ * @param options emit options that will be applied for all emits of all events
  */
 export function useBus<
   // biome-ignore lint/suspicious/noExplicitAny: intentional
@@ -54,7 +55,8 @@ export function useBus<
  * @template P union of event types
  * @template T type of event
  * @param type of type T, one of the event types
- * @returns callback that will accept the cooresponding payload to the previously entered event type
+ * @param options emit options that will be applied for all emits of this event
+ * @returns callback that will accept the cooresponding payload to the previously entered event type, callback will accept options as well that are not applied to all emits of this event type
  */
 export function useEmit<
   // biome-ignore lint/suspicious/noExplicitAny: intentional

--- a/packages/bus/src/react/index.ts
+++ b/packages/bus/src/react/index.ts
@@ -14,7 +14,7 @@
 import { useEffect, useRef } from 'react';
 import { Broadcast } from '../broadcast';
 import { useEffectEvent } from './ponyfill';
-import type { ExtractEvent, Payload } from '../broadcast/types';
+import type { EmitOptions, ExtractEvent, Payload } from '../broadcast/types';
 
 /**
  * A convenience wrapper for useEmit & useOn, to pass down types instead of having
@@ -51,6 +51,7 @@ export function useEmit<
   T extends P['type'] = P['type'],
 >(
   type: T,
+  options?: EmitOptions,
 ): ExtractEvent<P, T> extends { payload: infer Data }
   ? (payload: Data) => void
   : () => void {
@@ -62,7 +63,7 @@ export function useEmit<
         ? Data
         : never,
     ) => {
-      bus.current.emit(type, payload);
+      bus.current.emit(type, payload, options);
     },
   ) as ExtractEvent<P, T> extends { payload: infer Data }
     ? (payload: Data) => void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,14 +495,10 @@ importers:
         version: 8.5.0(@swc/core@1.7.36(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
 
   packages/bus:
-    dependencies:
+    devDependencies:
       '@accelint/core':
         specifier: workspace:*
         version: link:../core
-      typescript:
-        specifier: ^5.8.3
-        version: 5.9.2
-    devDependencies:
       '@accelint/typescript-config':
         specifier: workspace:*
         version: link:../../tooling/typescript-config
@@ -527,6 +523,9 @@ importers:
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.7.36(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.2
       vitest:
         specifier: 2.1.3
         version: 2.1.3(@types/node@24.3.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.44.0)
@@ -3276,7 +3275,6 @@ packages:
 
   '@ls-lint/ls-lint@2.3.0-beta.1':
     resolution: {integrity: sha512-NmujBNFslP4GhFsB92zh1evSSBadcg+RMsQ5FM70OrU36C3AbQYaVXDn4reC28GM6DFoOtiETRdKV6ie1TfP7g==}
-    cpu: [x64, arm64, s390x, ppc64le]
     os: [darwin, linux, win32]
     hasBin: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
 
   packages/bus:
     dependencies:
+      '@accelint/core':
+        specifier: workspace:*
+        version: link:../core
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
@@ -3273,6 +3276,7 @@ packages:
 
   '@ls-lint/ls-lint@2.3.0-beta.1':
     resolution: {integrity: sha512-NmujBNFslP4GhFsB92zh1evSSBadcg+RMsQ5FM70OrU36C3AbQYaVXDn4reC28GM6DFoOtiETRdKV6ie1TfP7g==}
+    cpu: [x64, arm64, s390x, ppc64le]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
Closes https://gohypergiant.atlassian.net/servicedesk/customer/portal/14/CORE-28

## ✅ Pull Request Checklist

- [] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions
1. omit options object from `bus.emit(...)` or `useEmit(...)`
2. Ensure events are propagated to all consumers. (same behavior as before)
3. Repeat but pass `{target: 'others'}` to `bus.emit(...)` or `useEmit(...)`
4. Ensure events are not self delivered.

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
