### PR TITLE
fix: slider height determined by its content

### DIFF
--- a/.changeset/spicy-birds-relate.md
+++ b/.changeset/spicy-birds-relate.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fixes an issue where the Slider component had a fixed height instead of being sized according to its content.

--- a/design-toolkit/components/src/components/slider/styles.ts
+++ b/design-toolkit/components/src/components/slider/styles.ts
@@ -20,7 +20,6 @@ export const SliderStyles = tv({
       'orientation-vertical:h-full orientation-vertical:w-fit',
       'orientation-vertical:layout-grid:grid-cols-[auto_auto_auto] orientation-vertical:layout-grid:grid-rows-[auto_auto_1fr_auto]',
       'orientation-vertical:layout-stack:flex-col',
-      'orientation-horizontal:h-xl',
       'orientation-horizontal:layout-grid:grid-cols-[auto_1fr_auto] orientation-horizontal:layout-grid:grid-rows-[auto_auto_auto]',
       'orientation-horizontal:layout-stack:w-full orientation-horizontal:layout-stack:items-center',
     ],


### PR DESCRIPTION
Fixes an issue where the Slider component had a fixed height (due to orientation-horizontal:h-xl class) instead of being sized according to its content.


Closes [PATH-819](https://gohypergiant.atlassian.net/browse/PATH-819)

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions
- Go to any of the `Slider` component stories and add an element underneath the `<Slider {...args} />` JSX:
```
    return (
      <div className='size-[400px]'>
        <Slider {...args} />
        <input type='text' />
      </div>
    )
```
- Open the corresponding `Slider` story in Storybook
- The element should be below the rendered `Slider` (as opposed to "on top" because of the fixed height from before)

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
### Before (`orientation-horizontal:h-xl` class applied)
<img width="306" height="101" alt="Screenshot 2025-10-01 at 9 38 12 PM" src="https://github.com/user-attachments/assets/f6c5c6e5-f0bd-437f-8c05-d42f72f20507" />
<img width="519" height="238" alt="Screenshot 2025-10-01 at 9 37 41 PM" src="https://github.com/user-attachments/assets/7787688d-379e-483c-bbb1-6cc013d11073" />

Note the `input` "on top" of the rendered slider because of the fixed height

### After removing `orientation-horizontal:h-xl` class:
<img width="565" height="233" alt="Screenshot 2025-10-01 at 10 10 29 PM" src="https://github.com/user-attachments/assets/68e053e7-3683-4a6a-8b12-2f8ed831d321" />

Note the `input` below the rendered slider, as expected


