### PR TITLE
fix: reference in map-mode to old dot notation

### DIFF
--- a/packages/map-toolkit/src/map-mode/map-mode.stories.tsx
+++ b/packages/map-toolkit/src/map-mode/map-mode.stories.tsx
@@ -15,8 +15,8 @@ import { type UniqueId, uuid } from '@accelint/core';
 import {
   Button,
   Divider,
-  Notice,
   NoticeEventTypes,
+  NoticeList,
   type NoticeQueueEvent,
 } from '@accelint/design-toolkit';
 import { useRef, useState } from 'react';
@@ -585,7 +585,7 @@ export const AuthorizationFlow: Story = {
           </div>
 
           {/* Notice list for stacking notifications */}
-          <Notice.List
+          <NoticeList
             placement='top right'
             defaultColor='serious'
             defaultTimeout={5000}


### PR DESCRIPTION
Closes no ticket. Missed one reference in the code with the older dot notation.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
