### PR TITLE
chore: convert TextLayer README to Storybook doc and add JSDocs

### DIFF
--- a/.changeset/common-trains-invent.md
+++ b/.changeset/common-trains-invent.md
@@ -1,0 +1,5 @@
+---
+"@accelint/map-toolkit": patch
+---
+
+Convert TextLayer README to Storybook doc and add JSDocs

--- a/packages/map-toolkit/src/deckgl/text-layer/character-sets.ts
+++ b/packages/map-toolkit/src/deckgl/text-layer/character-sets.ts
@@ -34,6 +34,13 @@ const EXPANDED = `${ASCII_ALL}${LATIN_ALL}`;
 
 export type CharacterSetsKeys = keyof typeof CHARACTER_SETS;
 
+/**
+ * Predefined character sets for TextLayer.
+ *
+ * Use smaller character sets (ASCII_ALL, ASCII_ALPHA_NUMERIC) for better performance,
+ * or use AUTO for dynamic optimization based on content.
+ * EXPANDED includes ASCII and Latin characters with diacritics for international text.
+ */
 export const CHARACTER_SETS = Object.freeze({
   ALL_NUMBERS,
 

--- a/packages/map-toolkit/src/deckgl/text-layer/default-settings.ts
+++ b/packages/map-toolkit/src/deckgl/text-layer/default-settings.ts
@@ -11,9 +11,9 @@
  */
 
 import type { Color } from '@deck.gl/core';
-import type { TextLayerProps } from '@deck.gl/layers';
+import type { TextLayerProps as DglTextLayerProps } from '@deck.gl/layers';
 
-export const defaultSettings: Partial<TextLayerProps> = {
+export const defaultSettings: Partial<DglTextLayerProps> = {
   fontFamily: 'system-ui, sans-serif',
   fontSettings: {
     fontSize: 22,

--- a/packages/map-toolkit/src/deckgl/text-layer/text-layer.docs.mdx
+++ b/packages/map-toolkit/src/deckgl/text-layer/text-layer.docs.mdx
@@ -1,8 +1,14 @@
-# `@accelint/map-toolkit/deckgl/text-layer`
+import { Meta } from '@storybook/addon-docs/blocks';
+
+import * as TextLayerStories from './text-layer.stories';
+
+<Meta of={TextLayerStories} />
+
+# Text Layer
 
 A Deck.gl text layer with enhanced styling capabilities including customizable fonts, colors, stroke, and extended character set support.
 
-The `TextLayer` wraps Deck.gl's `TextLayer` with [opinionated defaults](./default-settings.ts) and an [expanded character set](./character-sets.ts). Smaller character subsets are available for performance optimization.
+The `TextLayer` wraps Deck.gl's `TextLayer` with [opinionated defaults](https://github.com/gohypergiant/standard-toolkit/blob/main/packages/map-toolkit/src/deckgl/text-layer/default-settings.ts) and an [expanded character set](https://github.com/gohypergiant/standard-toolkit/blob/main/packages/map-toolkit/src/deckgl/text-layer/character-sets.ts). Smaller character subsets are available for performance optimization.
 
 ## Features
 
@@ -10,6 +16,26 @@ The `TextLayer` wraps Deck.gl's `TextLayer` with [opinionated defaults](./defaul
 - White text with black outline by default
 - Extended character set support
 - Performance-optimized character subsets available
+
+## Dependencies
+
+TextLayer requires the following dependencies:
+
+**Required:**
+- [`@deck.gl/core`](https://deck.gl/) - Deck.gl core library for WebGL visualization
+- [`@deck.gl/layers`](https://deck.gl/) - Deck.gl layers including the base TextLayer
+
+**React Integration:**
+- [`@deckgl-fiber-renderer/dom`](https://github.com/deckgl-fiber-renderer/fiber.gl) - React renderer for Deck.gl
+- `react` - React 19.0.0 or higher for using with the fiber renderer
+
+**Installation:**
+
+```bash
+npm install @accelint/map-toolkit @deck.gl/core @deck.gl/layers
+# or
+pnpm add @accelint/map-toolkit @deck.gl/core @deck.gl/layers
+```
 
 ## Usage
 
@@ -25,16 +51,16 @@ const layer = new TextLayer({
   ],
   getText: (d) => d.text,
   getPosition: (d) => d.position,
-  
+
   // Styling options
   getSize: 10, // Font size in pixels (can also be a function: d => d.fontSize)
   fontWeight: 500,
   fontFamily: 'Arial, sans-serif',
   lineHeight: 1.2,
-  
+
   // Colors - provide a Color array directly or a function that returns a Color array
   getColor: [255, 255, 255, 255], // White text
-  
+
   // Stroke
   outlineWidth: 1,
   outlineColor: [0, 0, 0, 255], // Black outline
@@ -62,8 +88,8 @@ export function TextLabelsLayer() {
   const data = useTextData();
 
   return (
-    <textLayer 
-      data={data} 
+    <textLayer
+      data={data}
       getSize={10}
       fontWeight={500}
       lineHeight={1.2}
@@ -73,6 +99,7 @@ export function TextLabelsLayer() {
   );
 }
 ```
+
 
 ## Performance
 
@@ -142,4 +169,4 @@ Interactive Storybook examples are available demonstrating:
 - Per-item color customization
 - Multiple layers composed together
 
-Run `pnpm --filter @accelint/map-toolkit run preview` from the monorepo root to view the interactive Storybook examples.
+Run `pnpm --filter @accelint/map-toolkit run storybook` from the monorepo root to view the interactive Storybook examples.


### PR DESCRIPTION
Closes no ticket

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

run map-toolkit storybook, notice the TextLayer now has a Docs page like the other layers.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 💬 Other information
