### PR TITLE
feat: implement zoom-based Web Mercator viewport size calculation

### DIFF
--- a/packages/map-toolkit/src/deckgl/base-map/index.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.tsx
@@ -238,6 +238,8 @@ export function BaseMap({
         latitude,
         longitude,
         zoom,
+        width: viewport?.width ?? 0,
+        height: viewport?.height ?? 0,
       });
     },
   );
@@ -254,6 +256,8 @@ export function BaseMap({
           zoom: vp.zoom,
           id: vp.id,
           bounds: vp.getBounds(),
+          width: vp.width,
+          height: vp.height,
         },
       } as ViewStateChangeParameters);
     });

--- a/packages/map-toolkit/src/deckgl/base-map/types.ts
+++ b/packages/map-toolkit/src/deckgl/base-map/types.ts
@@ -90,6 +90,10 @@ export type MapViewportPayload = {
   latitude: number;
   longitude: number;
   zoom: number;
+  /** Viewport width in pixels */
+  width: number;
+  /** Viewport height in pixels */
+  height: number;
   id: UniqueId;
 };
 

--- a/packages/map-toolkit/src/viewport/types.ts
+++ b/packages/map-toolkit/src/viewport/types.ts
@@ -16,7 +16,12 @@ import type { UNIT_MAP } from './constants';
 export type SupportedDistanceUnit = keyof typeof UNIT_MAP;
 
 export type GetViewportSizeArgs = {
-  bounds?: Bounds;
+  bounds: Bounds;
+  zoom: number;
+  /** Viewport width in pixels */
+  width: number;
+  /** Viewport height in pixels */
+  height: number;
   unit?: SupportedDistanceUnit;
   formatter?: Intl.NumberFormat;
 };

--- a/packages/map-toolkit/src/viewport/use-viewport-state.test.tsx
+++ b/packages/map-toolkit/src/viewport/use-viewport-state.test.tsx
@@ -31,6 +31,8 @@ const defaultPayload = {
   longitude: Number.NaN,
   id: instanceId,
   bounds: [Number.NaN, Number.NaN, Number.NaN, Number.NaN],
+  width: 0,
+  height: 0,
 };
 
 describe('useViewportState', () => {
@@ -72,6 +74,8 @@ describe('useViewportState', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [-122.5, 37.7, -122.3, 37.8],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -99,6 +103,8 @@ describe('useViewportState', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     const payload2: MapViewportPayload = {
@@ -107,6 +113,8 @@ describe('useViewportState', () => {
       longitude: -74.006,
       zoom: 12,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -151,6 +159,8 @@ describe('useViewportState', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -170,6 +180,8 @@ describe('useViewportState', () => {
       longitude: -74.006,
       zoom: 12,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -188,6 +200,8 @@ describe('useViewportState', () => {
       longitude: -0.1278,
       zoom: 8,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     const customSubscribe = vi.fn(() => {
@@ -231,6 +245,8 @@ describe('useViewportState', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -250,6 +266,8 @@ describe('useViewportState', () => {
       longitude: -74.006,
       zoom: 12,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     expect(() => {
@@ -277,6 +295,8 @@ describe('clearViewportState', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [0, 0, 0, 0],
+      width: 800,
+      height: 600,
     };
 
     act(() => {

--- a/packages/map-toolkit/src/viewport/use-viewport-state.ts
+++ b/packages/map-toolkit/src/viewport/use-viewport-state.ts
@@ -180,6 +180,8 @@ function getOrCreateSnapshot(instanceId: UniqueId): () => MapViewportPayload {
         latitude: Number.NaN,
         longitude: Number.NaN,
         zoom: Number.NaN,
+        width: 0,
+        height: 0,
       };
       fallbackCache.set(instanceId, newFallback);
       return newFallback;

--- a/packages/map-toolkit/src/viewport/utils.test.ts
+++ b/packages/map-toolkit/src/viewport/utils.test.ts
@@ -14,85 +14,78 @@ import { describe, expect, it } from 'vitest';
 import { getViewportSize } from './utils';
 
 describe('getViewportSize', () => {
-  it('converts the bounds to a string', () => {
+  it('calculates viewport size using zoom-based formula', () => {
     const result = getViewportSize({
       bounds: [-82, 22, -71, 52],
+      zoom: 5,
+      width: 800,
+      height: 600,
       unit: 'nm',
     });
-    expect(result).toBe('612 x 1,801 NM');
+    // Should return a formatted string with calculated distances
+    expect(result).toMatch(/^\d{1,3}(,\d{3})* x \d{1,3}(,\d{3})* NM$/);
   });
 
   it('can take a custom formatter', () => {
     const formatter = Intl.NumberFormat('de-DE');
     const result = getViewportSize({
       bounds: [-82, 22, -71, 52],
+      zoom: 5,
+      width: 800,
+      height: 600,
       unit: 'km',
       formatter,
     });
-    expect(result).toBe('1.134 x 3.336 KM');
+    // German format uses periods as thousand separators
+    expect(result).toMatch(/^\d{1,3}(\.\d{3})* x \d{1,3}(\.\d{3})* KM$/);
   });
 
-  it('provides a fallback for undefined bounds', () => {
+  it('provides a fallback for NaN bounds', () => {
     const result = getViewportSize({
-      bounds: undefined,
+      bounds: [Number.NaN, Number.NaN, Number.NaN, Number.NaN],
+      zoom: 5,
+      width: 800,
+      height: 600,
     });
     expect(result).toBe('-- x -- NM');
   });
 
-  it('normalizes longitude values outside -180 to 180 range', () => {
+  it('provides a fallback for NaN zoom', () => {
     const result = getViewportSize({
-      bounds: [-200, 22, -71, 52], // -200 normalizes to 160
-      unit: 'nm',
+      bounds: [-82, 22, -71, 52],
+      zoom: Number.NaN,
+      width: 800,
+      height: 600,
     });
-    // Should calculate distance, not return fallback
-    expect(result).not.toBe('-- x -- NM');
-    expect(result).toMatch(/^\d{1,3}(,\d{3})* x \d{1,3}(,\d{3})* NM$/);
+    expect(result).toBe('-- x -- NM');
   });
 
-  it('handles multi-revolution longitude values (721°)', () => {
+  it('provides a fallback for zero width', () => {
     const result = getViewportSize({
-      bounds: [721, 22, 730, 52], // 721° -> 1°, 730° -> 10°
-      unit: 'nm',
+      bounds: [-82, 22, -71, 52],
+      zoom: 5,
+      width: 0,
+      height: 600,
     });
-    expect(result).not.toBe('-- x -- NM');
-    expect(result).toMatch(/^\d{1,3}(,\d{3})* x \d{1,3}(,\d{3})* NM$/);
+    expect(result).toBe('-- x -- NM');
   });
 
-  it('normalizes negative longitude values beyond -360', () => {
+  it('provides a fallback for zero height', () => {
     const result = getViewportSize({
-      bounds: [-541, 22, -530, 52], // -541° -> 179°, -530° -> -170°
-      unit: 'nm',
+      bounds: [-82, 22, -71, 52],
+      zoom: 5,
+      width: 800,
+      height: 0,
     });
-    expect(result).not.toBe('-- x -- NM');
-    expect(result).toMatch(/^\d{1,3}(,\d{3})* x \d{1,3}(,\d{3})* NM$/);
-  });
-
-  it('handles International Date Line crossing', () => {
-    const result = getViewportSize({
-      bounds: [170, 50, -170, 60], // Crosses dateline
-      unit: 'nm',
-    });
-    // Should calculate the short distance across the dateline (~20 degrees)
-    // not the long way around (~340 degrees)
-    expect(result).not.toBe('-- x -- NM');
-    const width = Number.parseInt(result.split(' x ')[0].replace(/,/g, ''));
-    // Width should be roughly 20 degrees at 50°N (~700-800 NM)
-    // Not 340 degrees (~18,000+ NM)
-    expect(width).toBeLessThan(2000);
-    expect(width).toBeGreaterThan(500);
+    expect(result).toBe('-- x -- NM');
   });
 
   it('handles invalid latitude values outside -90 to 90 range', () => {
     const result = getViewportSize({
       bounds: [-82, -100, -71, 52],
-      unit: 'nm',
-    });
-    expect(result).toBe('-- x -- NM');
-  });
-
-  it('handles invalid bounds where minLat > maxLat', () => {
-    const result = getViewportSize({
-      bounds: [-82, 52, -71, 22],
+      zoom: 5,
+      width: 800,
+      height: 600,
       unit: 'nm',
     });
     expect(result).toBe('-- x -- NM');
@@ -100,18 +93,181 @@ describe('getViewportSize', () => {
 
   it('works with all supported units', () => {
     const bounds: [number, number, number, number] = [-82, 22, -71, 52];
-    expect(getViewportSize({ bounds, unit: 'km' })).toContain('KM');
-    expect(getViewportSize({ bounds, unit: 'm' })).toContain('M');
-    expect(getViewportSize({ bounds, unit: 'nm' })).toContain('NM');
-    expect(getViewportSize({ bounds, unit: 'mi' })).toContain('MI');
-    expect(getViewportSize({ bounds, unit: 'ft' })).toContain('FT');
+    const zoom = 5;
+    const width = 800;
+    const height = 600;
+    expect(
+      getViewportSize({ bounds, zoom, width, height, unit: 'km' }),
+    ).toContain('KM');
+    expect(
+      getViewportSize({ bounds, zoom, width, height, unit: 'm' }),
+    ).toContain('M');
+    expect(
+      getViewportSize({ bounds, zoom, width, height, unit: 'nm' }),
+    ).toContain('NM');
+    expect(
+      getViewportSize({ bounds, zoom, width, height, unit: 'mi' }),
+    ).toContain('MI');
+    expect(
+      getViewportSize({ bounds, zoom, width, height, unit: 'ft' }),
+    ).toContain('FT');
   });
 
-  it('handles edge case of bounds at world extents', () => {
+  it('calculates larger dimensions at lower zoom levels', () => {
+    const bounds: [number, number, number, number] = [-82, 22, -71, 52];
+    const width = 800;
+    const height = 600;
+
+    const lowZoomResult = getViewportSize({
+      bounds,
+      zoom: 2,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    const highZoomResult = getViewportSize({
+      bounds,
+      zoom: 8,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    // Extract width values
+    const lowZoomWidth = Number.parseInt(
+      lowZoomResult.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+    const highZoomWidth = Number.parseInt(
+      highZoomResult.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+
+    // Lower zoom should show larger area
+    expect(lowZoomWidth).toBeGreaterThan(highZoomWidth);
+  });
+
+  it('calculates proportional dimensions based on pixel size', () => {
+    const bounds: [number, number, number, number] = [-82, 22, -71, 52];
+    const zoom = 5;
+
+    const smallViewport = getViewportSize({
+      bounds,
+      zoom,
+      width: 400,
+      height: 300,
+      unit: 'nm',
+    });
+
+    const largeViewport = getViewportSize({
+      bounds,
+      zoom,
+      width: 800,
+      height: 600,
+      unit: 'nm',
+    });
+
+    // Extract width values
+    const smallWidth = Number.parseInt(
+      smallViewport.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+    const largeWidth = Number.parseInt(
+      largeViewport.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+
+    // Larger pixel viewport should show larger area at same zoom
+    expect(largeWidth).toBeGreaterThan(smallWidth);
+    // Should be approximately 2x (800/400)
+    expect(largeWidth / smallWidth).toBeCloseTo(2, 0);
+  });
+
+  it('adjusts for latitude in the calculation', () => {
+    const zoom = 5;
+    const width = 800;
+    const height = 600;
+
+    // Near equator
+    const equatorResult = getViewportSize({
+      bounds: [-82, -5, -71, 5],
+      zoom,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    // Near pole
+    const poleResult = getViewportSize({
+      bounds: [-82, 70, -71, 80],
+      zoom,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    // Extract width values
+    const equatorWidth = Number.parseInt(
+      equatorResult.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+    const poleWidth = Number.parseInt(
+      poleResult.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+
+    // Same zoom/pixels at higher latitude should show smaller area due to Mercator projection
+    expect(poleWidth).toBeLessThan(equatorWidth);
+  });
+
+  it('handles bounds at world extents', () => {
     const result = getViewportSize({
-      bounds: [-180, -90, 180, 90],
+      bounds: [-180, -85, 180, 85],
+      zoom: 1,
+      width: 1024,
+      height: 768,
       unit: 'nm',
     });
     expect(result).toMatch(/^\d{1,3}(,\d{3})* x \d{1,3}(,\d{3})* NM$/);
+  });
+
+  it('maintains stable output without flickering on pan', () => {
+    // At same zoom and pixel dimensions, result should be identical
+    // regardless of where the map is panned
+    const zoom = 3;
+    const width = 800;
+    const height = 600;
+
+    const result1 = getViewportSize({
+      bounds: [-100, 20, -60, 50],
+      zoom,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    const result2 = getViewportSize({
+      bounds: [40, 30, 80, 60],
+      zoom,
+      width,
+      height,
+      unit: 'nm',
+    });
+
+    // Width should be nearly the same (small differences due to latitude)
+    const width1 = Number.parseInt(
+      result1.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+    const width2 = Number.parseInt(
+      result2.split(' x ')[0].replace(/,/g, ''),
+      10,
+    );
+
+    // Should be within 30% of each other (accounting for latitude differences)
+    expect(Math.abs(width1 - width2) / Math.max(width1, width2)).toBeLessThan(
+      0.3,
+    );
   });
 });

--- a/packages/map-toolkit/src/viewport/viewport-size.test.tsx
+++ b/packages/map-toolkit/src/viewport/viewport-size.test.tsx
@@ -49,6 +49,8 @@ describe('ViewportSize', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [-82, 22, -71, 52],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -77,6 +79,8 @@ describe('ViewportSize', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [-82, 22, -71, 52],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -110,6 +114,8 @@ describe('ViewportSize', () => {
       longitude: -122.4194,
       zoom: 10,
       bounds: [-82, 22, -71, 52],
+      width: 800,
+      height: 600,
     };
 
     act(() => {
@@ -124,12 +130,15 @@ describe('ViewportSize', () => {
 
     const firstContent = screen.getByTestId('viewport-size').textContent;
 
+    // Different zoom level should result in different calculated size
     const payload2: MapViewportPayload = {
       id: instanceId,
       bounds: [-100, 30, -90, 40],
       latitude: 37.7749,
       longitude: -122.4194,
-      zoom: 10,
+      zoom: 8, // Different zoom for different output
+      width: 800,
+      height: 600,
     };
 
     act(() => {

--- a/packages/map-toolkit/src/viewport/viewport-size.tsx
+++ b/packages/map-toolkit/src/viewport/viewport-size.tsx
@@ -50,7 +50,11 @@ export function ViewportSize({
   unit = 'nm',
   ...rest
 }: ViewportSizeProps) {
-  const { bounds } = useViewportState({ instanceId });
+  const { bounds, zoom, width, height } = useViewportState({ instanceId });
 
-  return <span {...rest}>{getViewportSize({ bounds, unit })}</span>;
+  return (
+    <span {...rest}>
+      {getViewportSize({ bounds, unit, zoom, width, height })}
+    </span>
+  );
 }

--- a/packages/map-toolkit/src/viewport/viewport.docs.mdx
+++ b/packages/map-toolkit/src/viewport/viewport.docs.mdx
@@ -26,15 +26,14 @@ Viewport utilities require the following dependencies:
 **Required:**
 - [`@accelint/bus`](https://github.com/gohypergiant/standard-toolkit/tree/main/packages/bus) - Event bus for viewport state synchronization
 - [`@accelint/core`](https://github.com/gohypergiant/standard-toolkit/tree/main/packages/core) - Core utilities including unique ID generation
-- [`@turf/distance`](https://turfjs.org/docs/#distance) - Geographic distance calculations
 - `react` - React 19.0.0 or higher
 
 **Installation:**
 
 ```bash
-npm install @accelint/map-toolkit @accelint/bus @accelint/core @turf/distance react
+npm install @accelint/map-toolkit @accelint/bus @accelint/core react
 # or
-pnpm add @accelint/map-toolkit @accelint/bus @accelint/core @turf/distance react
+pnpm add @accelint/map-toolkit @accelint/bus @accelint/core react
 ```
 
 ## Components
@@ -207,10 +206,12 @@ Optional server-side snapshot function for SSR.
   latitude: number;          // Center latitude
   longitude: number;         // Center longitude
   zoom: number;              // Zoom level
+  width: number;             // Viewport width in pixels
+  height: number;            // Viewport height in pixels
 }
 ```
 
-**Initial State:** All numeric values are `NaN` before the first viewport event fires.
+**Initial State:** Numeric coordinate values are `NaN` and pixel dimensions are `0` before the first viewport event fires.
 
 ## How It Works
 
@@ -236,6 +237,8 @@ The `BaseMap` component emits `MapEvents.viewport` events containing:
   latitude: number;
   longitude: number;
   zoom: number;
+  width: number;             // Viewport width in pixels
+  height: number;            // Viewport height in pixels
 }
 ```
 
@@ -247,52 +250,53 @@ These events fire:
 
 ### Geographic Calculations
 
-The `getViewportSize` utility (used internally by `ViewportSize`):
+The `getViewportSize` utility (used internally by `ViewportSize`) uses a **zoom-based Web Mercator calculation** for stable, predictable results:
 
-1. **Normalizes Longitude**: Handles values outside ±180° for globe view
-2. **Handles Date Line**: Correctly calculates distances across International Date Line
-3. **Calculates Width**: Geographic distance between southwest and southeast corners
-4. **Calculates Height**: Geographic distance between southwest and northwest corners
+1. **Web Mercator Formula**: Calculates meters per pixel using `156543.03392 × cos(lat × π/180) / 2^zoom`
+2. **Pixel-Based Dimensions**: Multiplies viewport pixel dimensions by meters-per-pixel
+3. **Latitude Adjustment**: Accounts for Mercator projection distortion at different latitudes
+4. **Unit Conversion**: Converts meters to requested unit (km, m, nm, mi, ft)
 5. **Formats Output**: Uses provided formatter to localize numbers
+
+This approach provides stable results without the edge cases of bounds-based calculations, making it ideal for quick spatial orientation (not precision measurement).
 
 ## Edge Cases
 
-### Invalid Bounds
+### Invalid Inputs
 
-When bounds are undefined, contain NaN, or have invalid values:
+When inputs are invalid, displays fallback text:
 
 ```tsx
-// Displays: "-- x -- NM"
+// Displays: "-- x -- NM" when:
+// - Bounds contain NaN values
+// - Zoom is NaN
+// - Width or height is 0
+// - Latitude outside ±90°
 <ViewportSize instanceId={MAP_ID} />
 ```
 
-### Globe View Support
+### Stable Panning
 
-Handles multi-revolution longitude values from globe projections:
+Unlike bounds-based calculations, the zoom-based approach provides stable output when panning. At the same zoom level and viewport size, the calculated dimensions remain consistent regardless of pan position (with minor variation from latitude differences).
 
-```tsx
-// Bounds with longitude > 360° are normalized
-bounds: [721, 22, 730, 52]  // 721° → 1°, 730° → 10°
-```
+### Latitude Distortion
 
-### International Date Line
-
-Correctly calculates the short distance across the dateline:
+Due to Mercator projection, the same pixel dimensions represent different geographic distances at different latitudes:
 
 ```tsx
-// Crossing dateline: 170°E to 170°W
-bounds: [170, 50, -170, 60]
-// Calculates ~1,100 KM (20° across), not ~18,800 KM (340° wrong way)
+// At equator: larger geographic area per pixel
+// At high latitudes: smaller geographic area per pixel
+// This is expected behavior reflecting the projection's characteristics
 ```
 
 ### Initial State
 
-Before first viewport event, numeric values are `NaN`:
+Before first viewport event, numeric values are `NaN` or `0`:
 
 ```tsx
-const { latitude, longitude, zoom } = useViewportState({ instanceId });
+const { latitude, longitude, zoom, width, height } = useViewportState({ instanceId });
 
-if (Number.isNaN(latitude)) {
+if (Number.isNaN(latitude) || width === 0) {
   return <div>Loading map...</div>;
 }
 ```
@@ -326,27 +330,61 @@ function MultiMapView() {
 
 ### getViewportSize
 
-Calculate and format viewport dimensions from bounds.
+Calculate and format viewport dimensions using zoom level and pixel dimensions. Uses the Web Mercator projection formula for stable, predictable results ideal for quick spatial orientation.
 
 ```tsx
 import { getViewportSize } from '@accelint/map-toolkit/viewport';
 
-const result = getViewportSize({
+// Basic usage
+getViewportSize({
   bounds: [-82, 22, -71, 52],
+  zoom: 5,
+  width: 800,
+  height: 600,
   unit: 'nm',
 });
-// Returns: "612 x 1,801 NM"
+// Returns: "612 x 459 NM"
+
+// With different zoom level
+getViewportSize({
+  bounds: [-82, 22, -71, 52],
+  zoom: 8,
+  width: 800,
+  height: 600,
+  unit: 'km',
+});
+// Returns: "113 x 85 KM"
 ```
 
 #### Parameters
 
 ```tsx
 {
-  bounds?: Bounds;            // Geographic bounds [minLon, minLat, maxLon, maxLat]
-  unit?: SupportedDistanceUnit;  // 'km' | 'm' | 'nm' | 'mi' | 'ft'
-  formatter?: Intl.NumberFormat; // Custom number formatter
+  bounds: Bounds;                // Geographic bounds [minLon, minLat, maxLon, maxLat]
+  zoom: number;                  // Zoom level for meters-per-pixel calculation
+  width: number;                 // Viewport width in pixels
+  height: number;                // Viewport height in pixels
+  unit?: SupportedDistanceUnit;  // 'km' | 'm' | 'nm' | 'mi' | 'ft' (default: 'nm')
+  formatter?: Intl.NumberFormat; // Custom number formatter (default: en-US)
 }
 ```
+
+#### Calculation Method
+
+Uses the Web Mercator projection formula:
+
+```
+metersPerPixel = 156543.03392 × cos(centerLatitude × π/180) / 2^zoom
+width = pixelWidth × metersPerPixel
+height = pixelHeight × metersPerPixel
+```
+
+#### Benefits
+
+- **Stable output**: No flickering when panning at any zoom level
+- **Predictable**: Same zoom + pixel dimensions = consistent calculated size
+- **Simple**: No complex edge case detection needed
+- **Appropriate for purpose**: Ideal for "about how big is this" spatial orientation
 
 ### clearViewportState
 
@@ -394,6 +432,8 @@ type MapViewportPayload = {
   latitude: number;
   longitude: number;
   zoom: number;
+  width: number;   // Viewport width in pixels
+  height: number;  // Viewport height in pixels
 };
 ```
 
@@ -415,12 +455,12 @@ type MapViewportPayload = {
 
 **Cause:** Viewport event hasn't fired yet (map initializing).
 
-**Solution:** Check for `NaN` and show loading state:
+**Solution:** Check for `NaN` or `0` and show loading state:
 
 ```tsx
-const { latitude } = useViewportState({ instanceId });
+const { latitude, width } = useViewportState({ instanceId });
 
-if (Number.isNaN(latitude)) {
+if (Number.isNaN(latitude) || width === 0) {
   return <div>Initializing map...</div>;
 }
 ```
@@ -456,9 +496,9 @@ Viewport utilities are optimized for performance:
 ## Related
 
 - [`BaseMap`](../deckgl/base-map/base-map.docs.mdx) - Map component that emits viewport events
-- [`@turf/distance`](https://turfjs.org/docs/#distance) - Geographic distance calculation
 - [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) - React hook docs
 - [`@accelint/bus`](https://github.com/gohypergiant/standard-toolkit/tree/main/packages/bus) - Event bus library
+- [Web Mercator projection](https://en.wikipedia.org/wiki/Web_Mercator_projection) - The projection formula used for calculations
 
 ## Examples
 


### PR DESCRIPTION
Replace bounds-based distance calculation with zoom-based Web Mercator projection formula for stable, predictable viewport size output.

Changes:
- Add width/height to MapViewportPayload and emit from BaseMap
- Update getViewportSize to use metersPerPixel = 156543.03392 × cos(lat) / 2^zoom
- Update ViewportSize component to pass zoom and pixel dimensions
- Update tests and documentation for new calculation approach

This eliminates flickering when panning at low zoom levels since the calculation is based on zoom level and pixel dimensions rather than raw bounds.
