### PR TITLE
chore: zustand as direct dependency

### DIFF
--- a/packages/design-toolkit/package.json
+++ b/packages/design-toolkit/package.json
@@ -452,9 +452,6 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
-  "optionalDependencies": {
-    "zustand": "^5.0.3"
-  },
   "owner": "default/pathfinder",
   "peerDependencies": {
     "@accelint/bus": "workspace:*",
@@ -493,7 +490,8 @@
     "react-dom": "^19",
     "react-querybuilder": "~8.10.0",
     "uuid": "^11.1.0",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "zustand": "^5.0.3"
   },
   "private": false,
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,9 @@ importers:
       media-chrome:
         specifier: ^4.17.2
         version: 4.17.2(react@19.2.3)
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.9(@types/react@19.2.7)(immer@11.0.1)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@accelint/biome-config':
         specifier: workspace:*
@@ -761,10 +764,6 @@ importers:
       zod:
         specifier: ^4.1.12
         version: 4.2.1
-    optionalDependencies:
-      zustand:
-        specifier: ^5.0.3
-        version: 5.0.9(@types/react@19.2.7)(immer@11.0.1)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
 
   packages/formatters:
     devDependencies:
@@ -17662,7 +17661,6 @@ snapshots:
       immer: 11.0.1
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
-    optional: true
 
   zustand@5.0.9(@types/react@19.2.7)(react@19.2.3):
     optionalDependencies:


### PR DESCRIPTION
Sets zustand as a direct dependency in design-toolkit instead of an optional dependency.

Closes [PATH-1649](https://gohypergiant.atlassian.net/browse/PATH-1649).

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
N/A