### PR TITLE
fix: prevent unnecessary rerenders in coffin corner store

### DIFF
--- a/.changeset/nervous-boxes-warn.md
+++ b/.changeset/nervous-boxes-warn.md
@@ -1,0 +1,9 @@
+---
+"@accelint/map-toolkit": patch
+---
+
+fix: prevent useCoffinCorner from processing events before layer is configured
+
+The coffin corner store's `onClick` and `onHover` handlers were processing all map events even when `layerId` was undefined (before the hook's `useEffect` ran or during unmount). This caused unnecessary event processing and could lead to unexpected state updates.
+
+The fix adds guards to skip processing when no layer is configured, matching the pattern from the draw store fix (#968).

--- a/.changeset/nervous-boxes-warn.md
+++ b/.changeset/nervous-boxes-warn.md
@@ -2,8 +2,10 @@
 "@accelint/map-toolkit": patch
 ---
 
-fix: prevent useCoffinCorner from processing events before layer is configured
+fix: prevent unnecessary rerenders in useCoffinCorner on mount
 
-The coffin corner store's `onClick` and `onHover` handlers were processing all map events even when `layerId` was undefined (before the hook's `useEffect` ran or during unmount). This caused unnecessary event processing and could lead to unexpected state updates.
+Two changes work together to eliminate a startup rerender that was breaking deck.gl/maplibre sync:
 
-The fix adds guards to skip processing when no layer is configured, matching the pattern from the draw store fix (#968).
+1. `useCoffinCorner` now seeds `layerId` and `getEntityId` into the store via `setInitialState` before `use()` subscribes and sets up the bus. Because `setInitialState` writes directly without calling `notify()`, no rerender is triggered and the `useEffect`s that previously set these values on first mount become no-ops.
+
+2. The store's `onClick` and `onHover` handlers now guard against processing events when `layerId` is undefined (before the hook mounts or after unmount), matching the pattern from the draw store fix (#968).

--- a/.changeset/nervous-boxes-warn.md
+++ b/.changeset/nervous-boxes-warn.md
@@ -2,10 +2,31 @@
 "@accelint/map-toolkit": patch
 ---
 
-fix: prevent unnecessary rerenders in useCoffinCorner on mount
+fix: support multiple coffin-corner layers per map without breaking deck.gl/maplibre viewport sync
 
-Two changes work together to eliminate a startup rerender that was breaking deck.gl/maplibre sync:
+`useCoffinCorner` previously stored each layer's `getEntityId` accessor inside
+the reactive store. When a second layer registered, the shared state reference
+changed, triggering `useSyncExternalStore`'s post-commit snapshot-consistency
+check. The resulting mid-mount re-render desynced deck.gl's viewport from
+maplibre's on pan/zoom whenever two or more layers used the hook on the same map.
 
-1. `useCoffinCorner` now seeds `layerId` and `getEntityId` into the store via `setInitialState` before `use()` subscribes and sets up the bus. Because `setInitialState` writes directly without calling `notify()`, no rerender is triggered and the `useEffect`s that previously set these values on first mount become no-ops.
+Layer registration now lives in a non-reactive module-level registry. Reactive
+state holds only `selectedId` and `hoveredId`, which update exclusively via
+genuine user interaction through the map bus. The store is now multi-layer
+aware: `LayerState` is keyed by `layerId` inside a `Map`, and all bus payloads
+carry a `layerId`. Actions and bus handlers receive their owning `mapId` via
+closure rather than storing it in state.
 
-2. The store's `onClick` and `onHover` handlers now guard against processing events when `layerId` is undefined (before the hook mounts or after unmount), matching the pattern from the draw store fix (#968).
+**Breaking changes for direct store consumers:**
+
+- `CoffinCornerSelectedEvent`, `CoffinCornerDeselectedEvent`, and
+  `CoffinCornerHoveredEvent` payloads now include a required `layerId: string`
+  field.
+- `getSelectedEntityId(mapId)` and `getHoveredEntityId(mapId)` now require a
+  `layerId` argument: `getSelectedEntityId(mapId, layerId)`.
+- `clearSelection(mapId)` still clears the whole map; pass an optional
+  `layerId` to clear a single layer's state.
+- The `setLayerId` and `setGetEntityId` store actions are removed — use
+  `useCoffinCorner` (which handles registration) instead.
+
+`useCoffinCorner`'s public API is unchanged.

--- a/.changeset/nervous-boxes-warn.md
+++ b/.changeset/nervous-boxes-warn.md
@@ -1,32 +1,15 @@
 ---
-"@accelint/map-toolkit": patch
+"@accelint/map-toolkit": minor
 ---
 
-fix: support multiple coffin-corner layers per map without breaking deck.gl/maplibre viewport sync
+Fix viewport desync when multiple coffin-corner layers share a map, and add multi-layer support to `useCoffinCorner`
 
-`useCoffinCorner` previously stored each layer's `getEntityId` accessor inside
-the reactive store. When a second layer registered, the shared state reference
-changed, triggering `useSyncExternalStore`'s post-commit snapshot-consistency
-check. The resulting mid-mount re-render desynced deck.gl's viewport from
-maplibre's on pan/zoom whenever two or more layers used the hook on the same map.
+Using two or more `useCoffinCorner` hooks on the same `BaseMap` caused deck.gl's viewport to desync from maplibre's on pan/zoom. This happened because registering a second layer triggered a mid-mount re-render via `useSyncExternalStore`. Layer registration is now non-reactive, so adding layers no longer causes re-renders.
 
-Layer registration now lives in a non-reactive module-level registry. Reactive
-state holds only `selectedId` and `hoveredId`, which update exclusively via
-genuine user interaction through the map bus. The store is now multi-layer
-aware: `LayerState` is keyed by `layerId` inside a `Map`, and all bus payloads
-carry a `layerId`. Actions and bus handlers receive their owning `mapId` via
-closure rather than storing it in state.
+`useCoffinCorner`'s hook API is unchanged. The store and imperative APIs now require a `layerId` parameter to support multiple layers per map:
 
-**Breaking changes for direct store consumers:**
-
-- `CoffinCornerSelectedEvent`, `CoffinCornerDeselectedEvent`, and
-  `CoffinCornerHoveredEvent` payloads now include a required `layerId: string`
-  field.
-- `getSelectedEntityId(mapId)` and `getHoveredEntityId(mapId)` now require a
-  `layerId` argument: `getSelectedEntityId(mapId, layerId)`.
-- `clearSelection(mapId)` still clears the whole map; pass an optional
-  `layerId` to clear a single layer's state.
-- The `setLayerId` and `setGetEntityId` store actions are removed — use
-  `useCoffinCorner` (which handles registration) instead.
-
-`useCoffinCorner`'s public API is unchanged.
+- `getSelectedEntityId(mapId, layerId)` and `getHoveredEntityId(mapId, layerId)` now require `layerId`
+- `clearSelection(mapId, layerId?)` accepts an optional `layerId` to clear a single layer
+- Store actions `setSelectedId` and `deselect` now take `layerId` as the first argument
+- Event payloads (`CoffinCornerSelectedEvent`, `CoffinCornerDeselectedEvent`, `CoffinCornerHoveredEvent`) include a required `layerId` field
+- `setLayerId` and `setGetEntityId` store actions are removed — use `useCoffinCorner` or `registerCoffinCornerLayer` instead

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/coffin-corner.docs.mdx
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/coffin-corner.docs.mdx
@@ -41,12 +41,13 @@ The original approach used a separate icon atlas (sprite sheet) layer to draw co
 
 ## Architecture
 
-The system has three independent layers. The React hook is a convenience wrapper — you can use the store imperatively for non-React contexts.
+The system has three independent layers plus a non-reactive registry. The React hook is a convenience wrapper — you can use the store and registry imperatively for non-React contexts. Multiple layers per map are supported.
 
 | Layer | Module | Role |
 |-------|--------|------|
-| **React** | `useCoffinCorner(mapId, layerId)` | Reads state, sets `layerId` |
-| **Store** (framework-agnostic) | `coffinCornerStore` | Listens to map bus (click/hover events), emits domain events (selected/deselected), holds `{ selectedId, hoveredId }` |
+| **React** | `useCoffinCorner(mapId, layerId)` | Subscribes to the store, registers the layer's entity-ID accessor with the non-reactive registry, returns `selectedId` / `hoveredId` for the requested layer |
+| **Store** (framework-agnostic) | `coffinCornerStore` | Listens to map bus (click/hover events), emits domain events (selected/deselected/hovered), holds `Map<layerId, { selectedId, hoveredId }>` per map instance |
+| **Registry** (non-reactive) | `registerCoffinCornerLayer` / `unregisterCoffinCornerLayer` | Module-level `Map` that tracks which layers are opted in and their entity-ID accessors. Writes here never trigger store subscribers, so adding a layer does not re-render siblings |
 | **Extension** (pure deck.gl) | `CoffinCornerExtension` | Reads `selectedEntityId` / `hoveredEntityId`, injects SDF shader code into IconLayer/ScatterplotLayer, draws brackets on GPU |
 
 ## API
@@ -108,41 +109,51 @@ React hook that manages coffin corner selection/hover state. Subscribes to map b
 
 ---
 
-### Store (imperative)
+### Store and registry (imperative)
 
-For non-React contexts (orchestrated maps, vanilla JS, etc.), use the store API directly. Everything is exported from `@accelint/map-toolkit/deckgl`.
+For non-React contexts (orchestrated maps, vanilla JS, etc.), use the store API and registry directly. Everything is exported from `@accelint/map-toolkit/deckgl`.
 
 ```ts
 import {
   coffinCornerStore,
+  registerCoffinCornerLayer,
+  unregisterCoffinCornerLayer,
   getSelectedEntityId,
   getHoveredEntityId,
   clearSelection,
 } from '@accelint/map-toolkit/deckgl';
 ```
 
-#### `getSelectedEntityId(mapId)`
+#### `registerCoffinCornerLayer(mapId, layerId, getEntityId)`
 
-Read the selected entity ID for a map instance. Non-reactive (snapshot).
+Register a layer with the non-reactive registry. After this call, click/hover events on that deck.gl layer are routed through the coffin-corner domain events and update the store.
 
-#### `getHoveredEntityId(mapId)`
+Writes are invisible to `useSyncExternalStore` subscribers, so registering a new layer on an already-mounted map does not trigger a re-render of sibling components.
 
-Read the hovered entity ID for a map instance. Non-reactive (snapshot).
+#### `unregisterCoffinCornerLayer(mapId, layerId)`
 
-#### `clearSelection(mapId)`
+Remove a layer's registration. After this call, the bus handlers ignore interactions on that layer. Safe to call during component cleanup.
 
-Clear selection state and clean up the store instance.
+#### `getSelectedEntityId(mapId, layerId)`
+
+Read the selected entity ID for a specific layer on a map instance. Non-reactive (snapshot). Returns `undefined` if nothing is selected.
+
+#### `getHoveredEntityId(mapId, layerId)`
+
+Read the hovered entity ID for a specific layer on a map instance. Non-reactive (snapshot). Returns `undefined` if nothing is hovered.
+
+#### `clearSelection(mapId, layerId?)`
+
+Without a `layerId`, clears the entire store instance for the map. With a `layerId`, clears only that layer's selection and hover state. Useful for tests and teardown.
 
 #### `coffinCornerStore.actions(mapId)`
 
-Get action methods without subscribing to state changes.
+Get action methods without subscribing to state changes. All actions are scoped to a specific layer, so you pass `layerId` at call time.
 
 | Action | Type | Description |
 |--------|------|-------------|
-| `setSelectedId` | `(id: EntityId \| undefined) => void` | Set the selected entity |
-| `deselect` | `() => void` | Clear selection |
-| `setLayerId` | `(layerId: string) => void` | Set which layer to listen for interactions on |
-| `setGetEntityId` | `(fn: GetEntityId) => void` | Set the entity ID accessor |
+| `setSelectedId` | `(layerId: string, id: EntityId \| undefined) => void` | Set the selected entity for a layer |
+| `deselect` | `(layerId: string) => void` | Clear the selection for a layer |
 
 #### `coffinCornerStore.subscribe(mapId)`
 
@@ -154,13 +165,13 @@ Subscribe to state changes. Returns a function that accepts a callback and retur
 
 ### Events
 
-Domain events emitted via `@accelint/bus`:
+Domain events emitted via `@accelint/bus`. Every payload carries a `layerId` so handlers can scope to a specific layer on a map.
 
 | Event | Payload | Description |
 |-------|---------|-------------|
-| `coffin-corner:selected` | `{ selectedId, mapId }` | Entity was selected |
-| `coffin-corner:deselected` | `{ selectedId: undefined, mapId }` | Selection was cleared |
-| `coffin-corner:hovered` | `{ hoveredId, mapId }` | Hover state changed |
+| `coffin-corner:selected` | `{ selectedId, layerId, mapId }` | Entity was selected |
+| `coffin-corner:deselected` | `{ selectedId: undefined, layerId, mapId }` | Selection was cleared |
+| `coffin-corner:hovered` | `{ hoveredId, layerId, mapId }` | Hover state changed |
 
 Access event constants via `CoffinCornerEvents`:
 
@@ -233,12 +244,14 @@ function MyMap() {
 
 ### Imperative (without React)
 
-For orchestrated or non-React map instances. The store and bus have no React dependency.
+For orchestrated or non-React map instances. The store, registry, and bus have no React dependency.
 
 ```ts
 import { uuid } from '@accelint/core';
 import {
   coffinCornerStore,
+  registerCoffinCornerLayer,
+  unregisterCoffinCornerLayer,
   getSelectedEntityId,
   getHoveredEntityId,
   clearSelection,
@@ -246,27 +259,61 @@ import {
 
 // Same ID you pass to your Deck instance / BaseMap
 const mapId = uuid();
+const layerId = 'my-layer';
 
-// Get actions and configure
-const { setSelectedId, setLayerId } = coffinCornerStore.actions(mapId);
-setLayerId('my-layer');
+// Register the layer so the bus handlers know how to extract entity IDs.
+registerCoffinCornerLayer(mapId, layerId, (item) => item.id);
 
-// Subscribe to changes — also wires up bus listeners on first call
+// Subscribe to changes — also wires up bus listeners on first call.
 const unsubscribe = coffinCornerStore.subscribe(mapId)(() => {
   const state = coffinCornerStore.get(mapId);
+  const layer = state.layers.get(layerId);
   // Update layer props, re-render deck.gl, etc.
 });
 
 // Read state imperatively at any time
-const selectedId = getSelectedEntityId(mapId);
-const hoveredId = getHoveredEntityId(mapId);
+const selectedId = getSelectedEntityId(mapId, layerId);
+const hoveredId = getHoveredEntityId(mapId, layerId);
 
-// Mutate state
-setSelectedId('entity-123');
+// Mutate state through the store's actions
+const { setSelectedId, deselect } = coffinCornerStore.actions(mapId);
+setSelectedId(layerId, 'entity-123');
 
 // Cleanup
-clearSelection(mapId);
+deselect(layerId);
+unregisterCoffinCornerLayer(mapId, layerId);
+clearSelection(mapId, layerId); // or clearSelection(mapId) to clear all layers
 unsubscribe();
+```
+
+### Multiple layers on one map
+
+A single map can have any number of registered coffin-corner layers. Each layer maintains its own selection and hover state. Clicking empty space deselects all layers; clicking a new entity on a different layer does not affect other layers' selections.
+
+```tsx
+function MyMap({ mapId }) {
+  const { selectedId: klvSelected } = useCoffinCorner(mapId, 'klv-tracks');
+  const { selectedId: cotSelected } = useCoffinCorner(mapId, 'cot-symbols');
+
+  return (
+    <BaseMap id={mapId}>
+      <symbolLayer
+        id="klv-tracks"
+        data={klvData}
+        pickable
+        extensions={[coffinCornerExtension]}
+        selectedEntityId={klvSelected}
+      />
+      <symbolLayer
+        id="cot-symbols"
+        data={cotData}
+        pickable
+        extensions={[coffinCornerExtension]}
+        selectedEntityId={cotSelected}
+      />
+    </BaseMap>
+  );
+}
 ```
 
 ### Custom entity ID accessor

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
@@ -19,6 +19,8 @@ import {
   coffinCornerStore,
   getHoveredEntityId,
   getSelectedEntityId,
+  registerCoffinCornerLayer,
+  unregisterCoffinCornerLayer,
 } from './store';
 import { CoffinCornerEvents } from './types';
 import type { UniqueId } from '@accelint/core';
@@ -78,20 +80,19 @@ describe('coffin-corner store', () => {
   beforeEach(() => {
     mapId = uuid();
     layerId = 'symbols';
-    // Initialize store state with mapId and a test layer
-    const layers = new Map();
-    layers.set(layerId, {
-      selectedId: undefined,
-      hoveredId: undefined,
-      getEntityId: (item: any) => item.id,
-    });
-    coffinCornerStore.setInitialState(mapId, {
-      layers,
+    // Seed an empty store instance and register the test layer with the
+    // non-reactive registry so bus handlers recognize it — same shape as
+    // what useCoffinCorner does at mount time.
+    coffinCornerStore.setInitialState(mapId, { layers: new Map() });
+    registerCoffinCornerLayer(
       mapId,
-    });
+      layerId,
+      (item: { id: string }) => item.id,
+    );
   });
 
   afterEach(() => {
+    unregisterCoffinCornerLayer(mapId, layerId);
     clearSelection(mapId);
   });
 
@@ -163,7 +164,6 @@ describe('coffin-corner store', () => {
       expect(state).not.toBeNull();
       expect(state?.layers.get(layerId)?.selectedId).toBeUndefined();
       expect(state?.layers.get(layerId)?.hoveredId).toBeUndefined();
-      expect(state?.mapId).toBe(mapId);
     });
   });
 
@@ -302,32 +302,26 @@ describe('coffin-corner store', () => {
     });
   });
 
-  describe('coffinCornerStore.actions().setGetEntityId', () => {
-    it('should update getEntityId in state', () => {
-      const customAccessor = (item: { uid: string }) => item.uid;
-      const { setGetEntityId } = coffinCornerStore.actions(mapId);
-
-      setGetEntityId(layerId, customAccessor);
-
-      const state = coffinCornerStore.get(mapId);
-      expect(state.layers.get(layerId)?.getEntityId).toBe(customAccessor);
-    });
-
-    it('should not trigger update when getEntityId is the same reference', () => {
-      const customAccessor = (item: { uid: string }) => item.uid;
-      const { setGetEntityId } = coffinCornerStore.actions(mapId);
-
-      setGetEntityId(layerId, customAccessor);
-
+  describe('registerCoffinCornerLayer', () => {
+    it('does not notify store subscribers when registering an accessor', () => {
+      // Registration is non-reactive by design — it must never trigger a
+      // re-render, or the mount-cycle notify storm it was built to prevent
+      // would return.
+      const otherLayer = 'other-layer';
       const subscription = coffinCornerStore.subscribe(mapId);
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
       callback.mockClear();
 
-      setGetEntityId(layerId, customAccessor);
+      registerCoffinCornerLayer(
+        mapId,
+        otherLayer,
+        (item: { uid: string }) => item.uid,
+      );
 
       expect(callback).not.toHaveBeenCalled();
 
+      unregisterCoffinCornerLayer(mapId, otherLayer);
       unsubscribe();
     });
   });
@@ -542,8 +536,11 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setGetEntityId } = coffinCornerStore.actions(mapId);
-      setGetEntityId(layerId, (item: { uid: string }) => item.uid);
+      registerCoffinCornerLayer(
+        mapId,
+        layerId,
+        (item: { uid: string }) => item.uid,
+      );
 
       mapBus.emit(
         MapEvents.click,
@@ -693,8 +690,11 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setGetEntityId } = coffinCornerStore.actions(mapId);
-      setGetEntityId(layerId, (item: { uid: string }) => item.uid);
+      registerCoffinCornerLayer(
+        mapId,
+        layerId,
+        (item: { uid: string }) => item.uid,
+      );
 
       mapBus.emit(
         MapEvents.hover,

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
@@ -17,6 +17,7 @@ import { MapEvents } from '../../base-map/events';
 import {
   clearSelection,
   coffinCornerStore,
+  defaultGetEntityId,
   getHoveredEntityId,
   getSelectedEntityId,
   registerCoffinCornerLayer,
@@ -778,7 +779,7 @@ describe('coffin-corner store', () => {
       layers.set(layerId, {
         selectedId: 'entity-5',
         hoveredId: undefined,
-        getEntityId: (item: any) => item.id,
+        getEntityId: defaultGetEntityId,
       });
       coffinCornerStore.set(mapId, { layers });
 
@@ -791,7 +792,7 @@ describe('coffin-corner store', () => {
       layers.set(layerId, {
         selectedId: undefined,
         hoveredId: 'entity-6',
-        getEntityId: (item: any) => item.id,
+        getEntityId: defaultGetEntityId,
       });
       coffinCornerStore.set(mapId, { layers });
 
@@ -804,7 +805,7 @@ describe('coffin-corner store', () => {
       layers.set(layerId, {
         selectedId: 'entity-5',
         hoveredId: 'entity-6',
-        getEntityId: (item: any) => item.id,
+        getEntityId: defaultGetEntityId,
       });
       coffinCornerStore.set(mapId, { layers });
 

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.test.ts
@@ -73,9 +73,22 @@ function createHoverEvent(id: UniqueId, info: Record<string, unknown> = {}) {
 
 describe('coffin-corner store', () => {
   let mapId: UniqueId;
+  let layerId: string;
 
   beforeEach(() => {
     mapId = uuid();
+    layerId = 'symbols';
+    // Initialize store state with mapId and a test layer
+    const layers = new Map();
+    layers.set(layerId, {
+      selectedId: undefined,
+      hoveredId: undefined,
+      getEntityId: (item: any) => item.id,
+    });
+    coffinCornerStore.setInitialState(mapId, {
+      layers,
+      mapId,
+    });
   });
 
   afterEach(() => {
@@ -109,7 +122,7 @@ describe('coffin-corner store', () => {
       const unsubscribe = subscription(callback);
       const { setSelectedId } = coffinCornerStore.actions(mapId);
 
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
 
       expect(callback).toHaveBeenCalled();
 
@@ -126,7 +139,7 @@ describe('coffin-corner store', () => {
       callback.mockClear();
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -148,9 +161,9 @@ describe('coffin-corner store', () => {
       const snapshot = coffinCornerStore.snapshot(mapId);
       const state = snapshot();
       expect(state).not.toBeNull();
-      expect(state?.selectedId).toBeUndefined();
-      expect(state?.hoveredId).toBeUndefined();
-      expect(state?.layerId).toBeUndefined();
+      expect(state?.layers.get(layerId)?.selectedId).toBeUndefined();
+      expect(state?.layers.get(layerId)?.hoveredId).toBeUndefined();
+      expect(state?.mapId).toBe(mapId);
     });
   });
 
@@ -161,11 +174,11 @@ describe('coffin-corner store', () => {
       bus.on(CoffinCornerEvents.SELECTED, selectedSpy);
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
 
       expect(selectedSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: { selectedId: 'entity-1', mapId },
+          payload: { selectedId: 'entity-1', layerId, mapId },
         }),
       );
 
@@ -184,14 +197,14 @@ describe('coffin-corner store', () => {
 
       // First select something (bus listener updates state)
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
 
       // Then deselect
-      setSelectedId(undefined);
+      setSelectedId(layerId, undefined);
 
       expect(deselectedSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: { mapId, selectedId: undefined },
+          payload: { mapId, layerId, selectedId: undefined },
         }),
       );
 
@@ -205,13 +218,13 @@ describe('coffin-corner store', () => {
       bus.on(CoffinCornerEvents.SELECTED, selectedSpy);
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId('entity-1');
-      setSelectedId('entity-2');
+      setSelectedId(layerId, 'entity-1');
+      setSelectedId(layerId, 'entity-2');
 
       expect(selectedSpy).toHaveBeenCalledTimes(2);
       expect(selectedSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          payload: { selectedId: 'entity-2', mapId },
+          payload: { selectedId: 'entity-2', layerId, mapId },
         }),
       );
 
@@ -228,10 +241,10 @@ describe('coffin-corner store', () => {
       const unsubscribe = subscription(callback);
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
       selectedSpy.mockClear();
 
-      setSelectedId('entity-1');
+      setSelectedId(layerId, 'entity-1');
 
       expect(selectedSpy).not.toHaveBeenCalled();
 
@@ -245,11 +258,11 @@ describe('coffin-corner store', () => {
       bus.on(CoffinCornerEvents.SELECTED, selectedSpy);
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId(0);
+      setSelectedId(layerId, 0);
 
       expect(selectedSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: { selectedId: 0, mapId },
+          payload: { selectedId: 0, layerId, mapId },
         }),
       );
 
@@ -262,7 +275,7 @@ describe('coffin-corner store', () => {
       bus.on(CoffinCornerEvents.DESELECTED, deselectedSpy);
 
       const { setSelectedId } = coffinCornerStore.actions(mapId);
-      setSelectedId(undefined);
+      setSelectedId(layerId, undefined);
 
       expect(deselectedSpy).not.toHaveBeenCalled();
 
@@ -277,11 +290,11 @@ describe('coffin-corner store', () => {
       bus.on(CoffinCornerEvents.DESELECTED, deselectedSpy);
 
       const { deselect } = coffinCornerStore.actions(mapId);
-      deselect();
+      deselect(layerId);
 
       expect(deselectedSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: { mapId, selectedId: undefined },
+          payload: { mapId, layerId, selectedId: undefined },
         }),
       );
 
@@ -294,52 +307,24 @@ describe('coffin-corner store', () => {
       const customAccessor = (item: { uid: string }) => item.uid;
       const { setGetEntityId } = coffinCornerStore.actions(mapId);
 
-      setGetEntityId(customAccessor);
+      setGetEntityId(layerId, customAccessor);
 
       const state = coffinCornerStore.get(mapId);
-      expect(state.getEntityId).toBe(customAccessor);
+      expect(state.layers.get(layerId)?.getEntityId).toBe(customAccessor);
     });
 
     it('should not trigger update when getEntityId is the same reference', () => {
       const customAccessor = (item: { uid: string }) => item.uid;
       const { setGetEntityId } = coffinCornerStore.actions(mapId);
 
-      setGetEntityId(customAccessor);
+      setGetEntityId(layerId, customAccessor);
 
       const subscription = coffinCornerStore.subscribe(mapId);
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
       callback.mockClear();
 
-      setGetEntityId(customAccessor);
-
-      expect(callback).not.toHaveBeenCalled();
-
-      unsubscribe();
-    });
-  });
-
-  describe('coffinCornerStore.actions().setLayerId', () => {
-    it('should update layerId in state', () => {
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-
-      setLayerId('my-layer');
-
-      const state = coffinCornerStore.get(mapId);
-      expect(state.layerId).toBe('my-layer');
-    });
-
-    it('should not trigger update when layerId is unchanged', () => {
-      const subscription = coffinCornerStore.subscribe(mapId);
-      const callback = vi.fn();
-      const unsubscribe = subscription(callback);
-
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-
-      setLayerId('my-layer');
-      callback.mockClear();
-
-      setLayerId('my-layer');
+      setGetEntityId(layerId, customAccessor);
 
       expect(callback).not.toHaveBeenCalled();
 
@@ -358,10 +343,13 @@ describe('coffin-corner store', () => {
 
       bus.emit(CoffinCornerEvents.SELECTED, {
         selectedId: 'entity-42',
+        layerId,
         mapId,
       });
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('entity-42');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'entity-42',
+      );
 
       unsubscribe();
     });
@@ -376,18 +364,24 @@ describe('coffin-corner store', () => {
       // Select first
       bus.emit(CoffinCornerEvents.SELECTED, {
         selectedId: 'entity-42',
+        layerId,
         mapId,
       });
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('entity-42');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'entity-42',
+      );
 
       // Deselect
       bus.emit(CoffinCornerEvents.DESELECTED, {
+        layerId,
         mapId,
         selectedId: undefined,
       });
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -401,10 +395,13 @@ describe('coffin-corner store', () => {
 
       bus.emit(CoffinCornerEvents.HOVERED, {
         hoveredId: 'entity-7',
+        layerId,
         mapId,
       });
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBe('entity-7');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId).toBe(
+        'entity-7',
+      );
 
       unsubscribe();
     });
@@ -419,10 +416,13 @@ describe('coffin-corner store', () => {
 
       bus.emit(CoffinCornerEvents.SELECTED, {
         selectedId: 'entity-99',
+        layerId,
         mapId: otherMapId,
       });
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -437,9 +437,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.click,
         createClickEvent(mapId, {
@@ -448,7 +445,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('entity-1');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'entity-1',
+      );
 
       unsubscribe();
     });
@@ -460,9 +459,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       const clickInfo = createClickEvent(mapId, {
         layerId: 'symbols',
         object: { id: 'entity-1' },
@@ -470,11 +466,15 @@ describe('coffin-corner store', () => {
 
       // First click selects
       mapBus.emit(MapEvents.click, clickInfo);
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('entity-1');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'entity-1',
+      );
 
       // Second click deselects
       mapBus.emit(MapEvents.click, clickInfo);
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -486,9 +486,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       // Select something first
       mapBus.emit(
         MapEvents.click,
@@ -498,7 +495,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('entity-1');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'entity-1',
+      );
 
       // Click empty space (index -1, no object)
       mapBus.emit(
@@ -506,7 +505,9 @@ describe('coffin-corner store', () => {
         createClickEvent(mapId, { index: -1, picked: false }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -519,9 +520,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.click,
         createClickEvent(otherMapId, {
@@ -530,7 +528,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -542,9 +542,8 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId, setGetEntityId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-      setGetEntityId((item: { uid: string }) => item.uid);
+      const { setGetEntityId } = coffinCornerStore.actions(mapId);
+      setGetEntityId(layerId, (item: { uid: string }) => item.uid);
 
       mapBus.emit(
         MapEvents.click,
@@ -554,7 +553,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe('custom-entity');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        'custom-entity',
+      );
 
       unsubscribe();
     });
@@ -566,9 +567,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.click,
         createClickEvent(mapId, {
@@ -577,7 +575,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBe(0);
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId).toBe(
+        0,
+      );
 
       unsubscribe();
     });
@@ -589,9 +589,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.click,
         createClickEvent(mapId, {
@@ -600,7 +597,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -615,9 +614,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       // Click empty space without any prior selection
       mapBus.emit(
         MapEvents.click,
@@ -625,7 +621,9 @@ describe('coffin-corner store', () => {
       );
 
       expect(deselectedSpy).not.toHaveBeenCalled();
-      expect(coffinCornerStore.get(mapId).selectedId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.selectedId,
+      ).toBeUndefined();
 
       bus.off(CoffinCornerEvents.DESELECTED, deselectedSpy);
       unsubscribe();
@@ -640,9 +638,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.hover,
         createHoverEvent(mapId, {
@@ -651,7 +646,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBe('entity-3');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId).toBe(
+        'entity-3',
+      );
 
       unsubscribe();
     });
@@ -663,9 +660,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       // Hover over entity
       mapBus.emit(
         MapEvents.hover,
@@ -675,7 +669,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBe('entity-3');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId).toBe(
+        'entity-3',
+      );
 
       // Hover away (no object)
       mapBus.emit(
@@ -683,7 +679,9 @@ describe('coffin-corner store', () => {
         createHoverEvent(mapId, { index: -1, picked: false }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -695,9 +693,8 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId, setGetEntityId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-      setGetEntityId((item: { uid: string }) => item.uid);
+      const { setGetEntityId } = coffinCornerStore.actions(mapId);
+      setGetEntityId(layerId, (item: { uid: string }) => item.uid);
 
       mapBus.emit(
         MapEvents.hover,
@@ -707,7 +704,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBe('hover-entity');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId).toBe(
+        'hover-entity',
+      );
 
       unsubscribe();
     });
@@ -720,9 +719,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       mapBus.emit(
         MapEvents.hover,
         createHoverEvent(otherMapId, {
@@ -731,7 +727,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -743,9 +741,6 @@ describe('coffin-corner store', () => {
       const callback = vi.fn();
       const unsubscribe = subscription(callback);
 
-      const { setLayerId } = coffinCornerStore.actions(mapId);
-      setLayerId('symbols');
-
       // Hover over matching layer
       mapBus.emit(
         MapEvents.hover,
@@ -755,7 +750,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBe('entity-3');
+      expect(coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId).toBe(
+        'entity-3',
+      );
 
       // Hover over a different layer's object
       mapBus.emit(
@@ -766,7 +763,9 @@ describe('coffin-corner store', () => {
         }),
       );
 
-      expect(coffinCornerStore.get(mapId).hoveredId).toBeUndefined();
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.hoveredId,
+      ).toBeUndefined();
 
       unsubscribe();
     });
@@ -774,35 +773,44 @@ describe('coffin-corner store', () => {
 
   describe('convenience exports', () => {
     it('should return selectedId via getSelectedEntityId', () => {
-      coffinCornerStore.set(mapId, {
+      const state = coffinCornerStore.get(mapId);
+      const layers = new Map(state.layers);
+      layers.set(layerId, {
         selectedId: 'entity-5',
         hoveredId: undefined,
-        layerId: undefined,
+        getEntityId: (item: any) => item.id,
       });
+      coffinCornerStore.set(mapId, { layers });
 
-      expect(getSelectedEntityId(mapId)).toBe('entity-5');
+      expect(getSelectedEntityId(mapId, layerId)).toBe('entity-5');
     });
 
     it('should return hoveredId via getHoveredEntityId', () => {
-      coffinCornerStore.set(mapId, {
+      const state = coffinCornerStore.get(mapId);
+      const layers = new Map(state.layers);
+      layers.set(layerId, {
         selectedId: undefined,
         hoveredId: 'entity-6',
-        layerId: undefined,
+        getEntityId: (item: any) => item.id,
       });
+      coffinCornerStore.set(mapId, { layers });
 
-      expect(getHoveredEntityId(mapId)).toBe('entity-6');
+      expect(getHoveredEntityId(mapId, layerId)).toBe('entity-6');
     });
 
     it('should clear all state for a mapId via clearSelection', () => {
-      coffinCornerStore.set(mapId, {
+      const state = coffinCornerStore.get(mapId);
+      const layers = new Map(state.layers);
+      layers.set(layerId, {
         selectedId: 'entity-5',
         hoveredId: 'entity-6',
-        layerId: 'symbols',
+        getEntityId: (item: any) => item.id,
       });
+      coffinCornerStore.set(mapId, { layers });
 
-      clearSelection(mapId);
+      clearSelection(mapId, layerId);
 
-      expect(coffinCornerStore.exists(mapId)).toBe(false);
+      expect(coffinCornerStore.get(mapId).layers.has(layerId)).toBe(false);
     });
   });
 

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
@@ -113,9 +113,13 @@ export function unregisterCoffinCornerLayer(
   layerId: string,
 ): void {
   const byLayer = layerRegistry.get(mapId);
-  if (!byLayer) return;
+  if (!byLayer) {
+    return;
+  }
   byLayer.delete(layerId);
-  if (byLayer.size === 0) layerRegistry.delete(mapId);
+  if (byLayer.size === 0) {
+    layerRegistry.delete(mapId);
+  }
 }
 
 function getRegisteredLayers(
@@ -170,6 +174,47 @@ const EMPTY_LAYER: LayerState = Object.freeze({
  */
 function readLayer(state: CoffinCornerState, layerId: string): LayerState {
   return state.layers.get(layerId) ?? EMPTY_LAYER;
+}
+
+/**
+ * Helper: Deselects all currently-selected layers for a map.
+ * Emits DESELECTED events for each layer that had a selection.
+ */
+function deselectAllLayers(mapId: UniqueId, state: CoffinCornerState): void {
+  for (const [layerId, layerState] of state.layers.entries()) {
+    if (layerState.selectedId !== undefined) {
+      coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
+        mapId,
+        layerId,
+        selectedId: undefined,
+      });
+    }
+  }
+}
+
+/**
+ * Helper: Handles clicking on an entity (object) - toggles selection.
+ * If already selected, deselects. Otherwise, selects the entity.
+ */
+function toggleEntitySelection(
+  mapId: UniqueId,
+  layerId: string,
+  entityId: EntityId,
+  currentSelected: EntityId | undefined,
+): void {
+  if (currentSelected === entityId) {
+    coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
+      mapId,
+      layerId,
+      selectedId: undefined,
+    });
+  } else {
+    coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
+      selectedId: entityId,
+      layerId,
+      mapId,
+    });
+  }
 }
 
 /**
@@ -310,24 +355,16 @@ export const coffinCornerStore = createMapStore<
       }
 
       const { info } = event.payload;
-      const clickedLayerId = info.layerId;
       const state = get();
 
       // If clicking empty space, deselect all currently-selected layers
       if (info.index === -1) {
-        for (const [layerId, layerState] of state.layers.entries()) {
-          if (layerState.selectedId !== undefined) {
-            coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-              mapId,
-              layerId,
-              selectedId: undefined,
-            });
-          }
-        }
+        deselectAllLayers(mapId, state);
         return;
       }
 
       // Check if the clicked layer is registered (via useCoffinCorner)
+      const clickedLayerId = info.layerId;
       if (!clickedLayerId) {
         return;
       }
@@ -337,24 +374,13 @@ export const coffinCornerStore = createMapStore<
         return;
       }
 
-      if (info.object) {
-        const entityId = getEntityId(info.object);
-        const currentSelected = readLayer(state, clickedLayerId).selectedId;
-
-        if (currentSelected === entityId) {
-          coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-            mapId,
-            layerId: clickedLayerId,
-            selectedId: undefined,
-          });
-        } else {
-          coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
-            selectedId: entityId,
-            layerId: clickedLayerId,
-            mapId,
-          });
-        }
+      if (!info.object) {
+        return;
       }
+
+      const entityId = getEntityId(info.object);
+      const currentSelected = readLayer(state, clickedLayerId).selectedId;
+      toggleEntitySelection(mapId, clickedLayerId, entityId, currentSelected);
     });
 
     // Map hovers → domain events

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
@@ -181,6 +181,11 @@ export const coffinCornerStore = createMapStore<
       const { info } = event.payload;
       const { layerId, selectedId, getEntityId: getId } = get();
 
+      // Guard: skip processing if no layer is configured
+      if (!layerId) {
+        return;
+      }
+
       if (info.layerId === layerId && info.object) {
         const entityId = getId(info.object);
 
@@ -219,6 +224,11 @@ export const coffinCornerStore = createMapStore<
         getEntityId: getId,
         hoveredId: currentHoveredId,
       } = get();
+
+      // Guard: skip processing if no layer is configured
+      if (!layerId) {
+        return;
+      }
 
       const hoveredId =
         info.layerId === layerId && info.object

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
@@ -13,7 +13,7 @@
 'use client';
 
 import { Broadcast } from '@accelint/bus';
-import { createMapStore } from '@/shared/create-map-store';
+import { createMapStore, mapDelete, mapSet } from '@/shared/create-map-store';
 import { MapEvents } from '../../base-map/events';
 import { CoffinCornerEvents } from './types';
 import type { UniqueId } from '@accelint/core';
@@ -33,18 +33,72 @@ type GetEntityId = (item: any) => EntityId;
 export const defaultGetEntityId: GetEntityId = (item: any) =>
   item.id as EntityId;
 
+// =============================================================================
+// Non-reactive layer registry
+// =============================================================================
+// Layer registration (getEntityId accessor + "is this layer tracked?") is held
+// OUTSIDE the reactive store. Writing to reactive state during mount — even
+// silently via setInitialState — causes useSyncExternalStore's post-commit
+// snapshot-consistency check to schedule a re-render, which desyncs deck.gl
+// from maplibre's viewport transforms. Plain Map writes are invisible to React.
+
+const layerRegistry = new Map<UniqueId, Map<string, GetEntityId>>();
+
+/** Register (or update) a layer's entity-id accessor. Non-reactive. */
+export function registerCoffinCornerLayer(
+  mapId: UniqueId,
+  layerId: string,
+  getEntityId: GetEntityId,
+): void {
+  let byLayer = layerRegistry.get(mapId);
+  if (!byLayer) {
+    byLayer = new Map();
+    layerRegistry.set(mapId, byLayer);
+  }
+  byLayer.set(layerId, getEntityId);
+}
+
+/** Remove a layer's registration. Non-reactive. */
+export function unregisterCoffinCornerLayer(
+  mapId: UniqueId,
+  layerId: string,
+): void {
+  const byLayer = layerRegistry.get(mapId);
+  if (!byLayer) return;
+  byLayer.delete(layerId);
+  if (byLayer.size === 0) layerRegistry.delete(mapId);
+}
+
+function getRegisteredAccessor(
+  mapId: UniqueId,
+  layerId: string,
+): GetEntityId | undefined {
+  return layerRegistry.get(mapId)?.get(layerId);
+}
+
+function getRegisteredLayerIds(mapId: UniqueId): Iterable<string> {
+  return layerRegistry.get(mapId)?.keys() ?? [];
+}
+
 /**
- * State for coffin corner selection and hover.
+ * State for a single layer's coffin corner selection and hover.
+ * Accessor lives in the non-reactive layerRegistry above.
  */
-type CoffinCornerState = {
+type LayerState = {
   /** Currently selected entity ID, or undefined if nothing is selected. */
   selectedId: EntityId | undefined;
   /** Currently hovered entity ID, or undefined if nothing is hovered. */
   hoveredId: EntityId | undefined;
-  /** deck.gl layer ID used to filter map bus events to only this layer's interactions. */
-  layerId: string | undefined;
-  /** Accessor to extract an entity ID from a picked data item. */
-  getEntityId: GetEntityId;
+};
+
+/**
+ * State for coffin corner - manages multiple layers per map.
+ */
+type CoffinCornerState = {
+  /** Map of layerId -> layer state */
+  layers: Map<string, LayerState>;
+  /** Map ID for filtering map bus events */
+  mapId: UniqueId;
 };
 
 /**
@@ -52,13 +106,9 @@ type CoffinCornerState = {
  */
 type CoffinCornerActions = {
   /** Select an entity by ID (emits domain event). Pass undefined to deselect. */
-  setSelectedId: (id: EntityId | undefined) => void;
+  setSelectedId: (layerId: string, id: EntityId | undefined) => void;
   /** Clear the current selection (emits deselect domain event). */
-  deselect: () => void;
-  /** Set the deck.gl layer ID used to filter map bus events. */
-  setLayerId: (layerId: string) => void;
-  /** Override the entity ID accessor for picked data items. */
-  setGetEntityId: (fn: GetEntityId) => void;
+  deselect: (layerId: string) => void;
 };
 
 const coffinCornerEventBus = Broadcast.getInstance<CoffinCornerEvent>();
@@ -76,27 +126,39 @@ const mapEventBus = Broadcast.getInstance<MapEventType>();
  * const { state, setSelectedId, deselect } = coffinCornerStore.use(mapId);
  * ```
  */
+/**
+ * Get or synthesize an ephemeral layer state entry. Does NOT write to state.
+ */
+function readLayer(state: CoffinCornerState, layerId: string): LayerState {
+  return (
+    state.layers.get(layerId) ?? {
+      selectedId: undefined,
+      hoveredId: undefined,
+    }
+  );
+}
+
 export const coffinCornerStore = createMapStore<
   CoffinCornerState,
   CoffinCornerActions
 >({
   defaultState: {
-    selectedId: undefined,
-    hoveredId: undefined,
-    layerId: undefined,
-    getEntityId: defaultGetEntityId,
+    layers: new Map(),
+    mapId: '' as UniqueId,
   },
 
   // Actions emit domain events rather than calling set() directly.
   // The bus subscriptions below translate events → state, ensuring
   // all state changes are observable by external subscribers.
-  actions: (mapId, { get, set }) => ({
-    setSelectedId: (id: EntityId | undefined) => {
-      const currentId = get().selectedId;
+  actions: (_mapId, { get }) => ({
+    setSelectedId: (layerId: string, id: EntityId | undefined) => {
+      const state = get();
+      const currentId = readLayer(state, layerId).selectedId;
 
       if (id == null && currentId != null) {
         coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-          mapId,
+          mapId: state.mapId,
+          layerId,
           selectedId: undefined,
         });
 
@@ -106,44 +168,42 @@ export const coffinCornerStore = createMapStore<
       if (id != null && currentId !== id) {
         coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
           selectedId: id,
-          mapId,
+          layerId,
+          mapId: state.mapId,
         });
 
         return;
       }
     },
 
-    deselect: () => {
+    deselect: (layerId: string) => {
       coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-        mapId,
+        mapId: get().mapId,
+        layerId,
         selectedId: undefined,
       });
     },
-
-    setLayerId: (layerId: string) => {
-      if (get().layerId !== layerId) {
-        set({ layerId });
-      }
-    },
-
-    setGetEntityId: (fn: GetEntityId) => {
-      if (get().getEntityId !== fn) {
-        set({ getEntityId: fn });
-      }
-    },
   }),
 
-  bus: (mapId, { get, set }) => {
+  bus: (_mapId, { get, set }) => {
     // Domain events → state
     const onSelected = coffinCornerEventBus.on(
       CoffinCornerEvents.SELECTED,
       (event) => {
-        if (event.payload.mapId !== mapId) {
+        const state = get();
+        if (event.payload.mapId !== state.mapId) {
           return;
         }
 
-        if (get().selectedId !== event.payload.selectedId) {
-          set({ selectedId: event.payload.selectedId });
+        const layerId = event.payload.layerId;
+        if (!layerId) {
+          return;
+        }
+
+        const layer = readLayer(state, layerId);
+        if (layer.selectedId !== event.payload.selectedId) {
+          const newLayer = { ...layer, selectedId: event.payload.selectedId };
+          set({ layers: mapSet(state.layers, layerId, newLayer) });
         }
       },
     );
@@ -151,12 +211,20 @@ export const coffinCornerStore = createMapStore<
     const onDeselected = coffinCornerEventBus.on(
       CoffinCornerEvents.DESELECTED,
       (event) => {
-        if (event.payload.mapId !== mapId) {
+        const state = get();
+        if (event.payload.mapId !== state.mapId) {
           return;
         }
 
-        if (get().selectedId !== undefined) {
-          set({ selectedId: undefined });
+        const layerId = event.payload.layerId;
+        if (!layerId) {
+          return;
+        }
+
+        const layer = state.layers.get(layerId);
+        if (layer && layer.selectedId !== undefined) {
+          const newLayer = { ...layer, selectedId: undefined };
+          set({ layers: mapSet(state.layers, layerId, newLayer) });
         }
       },
     );
@@ -164,83 +232,105 @@ export const coffinCornerStore = createMapStore<
     const onHovered = coffinCornerEventBus.on(
       CoffinCornerEvents.HOVERED,
       (event) => {
-        if (event.payload.mapId !== mapId) {
+        const state = get();
+        if (event.payload.mapId !== state.mapId) {
           return;
         }
-        if (get().hoveredId !== event.payload.hoveredId) {
-          set({ hoveredId: event.payload.hoveredId });
+
+        const layerId = event.payload.layerId;
+        if (!layerId) {
+          return;
+        }
+
+        const layer = readLayer(state, layerId);
+        if (layer.hoveredId !== event.payload.hoveredId) {
+          const newLayer = { ...layer, hoveredId: event.payload.hoveredId };
+          set({ layers: mapSet(state.layers, layerId, newLayer) });
         }
       },
     );
 
     // Map clicks → domain events
     const onClick = mapEventBus.on(MapEvents.click, (event: MapClickEvent) => {
-      if (event.payload.id !== mapId) {
+      const state = get();
+      if (event.payload.id !== state.mapId) {
         return;
       }
 
       const { info } = event.payload;
-      const { layerId, selectedId, getEntityId: getId } = get();
+      const clickedLayerId = info.layerId;
 
-      // Guard: skip processing if no layer is configured
-      if (!layerId) {
+      // If clicking empty space, deselect all currently-selected layers
+      if (info.index === -1) {
+        for (const [layerId, layerState] of state.layers.entries()) {
+          if (layerState.selectedId !== undefined) {
+            coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
+              mapId: state.mapId,
+              layerId,
+              selectedId: undefined,
+            });
+          }
+        }
         return;
       }
 
-      if (info.layerId === layerId && info.object) {
-        const entityId = getId(info.object);
+      // Check if the clicked layer is registered (via useCoffinCorner)
+      if (!clickedLayerId) {
+        return;
+      }
 
-        if (selectedId === entityId) {
+      const getEntityId = getRegisteredAccessor(state.mapId, clickedLayerId);
+      if (!getEntityId) {
+        return;
+      }
+
+      if (info.object) {
+        const entityId = getEntityId(info.object);
+        const currentSelected = readLayer(state, clickedLayerId).selectedId;
+
+        if (currentSelected === entityId) {
           coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-            mapId,
+            mapId: state.mapId,
+            layerId: clickedLayerId,
             selectedId: undefined,
           });
         } else {
           coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
             selectedId: entityId,
-            mapId,
+            layerId: clickedLayerId,
+            mapId: state.mapId,
           });
         }
-
-        return;
-      }
-
-      if (info.index === -1 && selectedId !== undefined) {
-        coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-          mapId,
-          selectedId: undefined,
-        });
       }
     });
 
     // Map hovers → domain events
     const onHover = mapEventBus.on(MapEvents.hover, (event: MapHoverEvent) => {
-      if (event.payload.id !== mapId) {
+      const state = get();
+      if (event.payload.id !== state.mapId) {
         return;
       }
 
       const { info } = event.payload;
-      const {
-        layerId,
-        getEntityId: getId,
-        hoveredId: currentHoveredId,
-      } = get();
+      const hoveredLayerId = info.layerId;
 
-      // Guard: skip processing if no layer is configured
-      if (!layerId) {
-        return;
-      }
+      // Walk every registered layer so we can emit an "unhover" event
+      // for a layer when the pointer moves off of it.
+      for (const layerId of getRegisteredLayerIds(state.mapId)) {
+        const accessor = getRegisteredAccessor(state.mapId, layerId);
+        const hoveredId =
+          accessor && hoveredLayerId === layerId && info.object
+            ? accessor(info.object)
+            : undefined;
 
-      const hoveredId =
-        info.layerId === layerId && info.object
-          ? getId(info.object)
-          : undefined;
-
-      if (currentHoveredId !== hoveredId) {
-        coffinCornerEventBus.emit(CoffinCornerEvents.HOVERED, {
-          hoveredId,
-          mapId,
-        });
+        const currentHovered = readLayer(state, layerId).hoveredId;
+        if (currentHovered !== hoveredId) {
+          coffinCornerEventBus.emit(CoffinCornerEvents.HOVERED, {
+            hoveredId,
+            layerId,
+            mapId: state.mapId,
+          });
+        }
       }
     });
 
@@ -262,42 +352,67 @@ export const coffinCornerStore = createMapStore<
  * Get selected entity ID imperatively (non-reactive).
  *
  * @param mapId - The map instance to query.
+ * @param layerId - The deck.gl layer ID.
  * @returns The selected entity ID, or undefined if nothing is selected.
  *
  * @example
  * ```typescript
- * const selectedId = getSelectedEntityId(mapId);
+ * const selectedId = getSelectedEntityId(mapId, 'klv-tracks');
  * ```
  */
-export function getSelectedEntityId(mapId: UniqueId): EntityId | undefined {
-  return coffinCornerStore.get(mapId).selectedId;
+export function getSelectedEntityId(
+  mapId: UniqueId,
+  layerId: string,
+): EntityId | undefined {
+  const state = coffinCornerStore.get(mapId);
+  const layer = state.layers.get(layerId);
+  return layer?.selectedId;
 }
 
 /**
  * Get hovered entity ID imperatively (non-reactive).
  *
  * @param mapId - The map instance to query.
+ * @param layerId - The deck.gl layer ID.
  * @returns The hovered entity ID, or undefined if nothing is hovered.
  *
  * @example
  * ```typescript
- * const hoveredId = getHoveredEntityId(mapId);
+ * const hoveredId = getHoveredEntityId(mapId, 'klv-tracks');
  * ```
  */
-export function getHoveredEntityId(mapId: UniqueId): EntityId | undefined {
-  return coffinCornerStore.get(mapId).hoveredId;
+export function getHoveredEntityId(
+  mapId: UniqueId,
+  layerId: string,
+): EntityId | undefined {
+  const state = coffinCornerStore.get(mapId);
+  const layer = state.layers.get(layerId);
+  return layer?.hoveredId;
 }
 
 /**
  * Clear selection state (for tests/cleanup).
+ * If layerId is provided, clears only that layer's state.
+ * If layerId is omitted, clears all layers for the map.
  *
  * @param mapId - The map instance to clear selection for.
+ * @param layerId - Optional deck.gl layer ID. If omitted, clears entire map state.
  *
  * @example
  * ```typescript
+ * // Clear all layers for a map
  * clearSelection(mapId);
+ *
+ * // Clear specific layer
+ * clearSelection(mapId, 'klv-tracks');
  * ```
  */
-export function clearSelection(mapId: UniqueId): void {
-  coffinCornerStore.clear(mapId);
+export function clearSelection(mapId: UniqueId, layerId?: string): void {
+  if (layerId) {
+    const state = coffinCornerStore.get(mapId);
+    const newLayers = mapDelete(state.layers, layerId);
+    coffinCornerStore.set(mapId, { layers: newLayers });
+  } else {
+    coffinCornerStore.clear(mapId);
+  }
 }

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
@@ -30,7 +30,8 @@ type GetEntityId = (item: any) => EntityId;
 
 /** Default accessor — assumes the data item has an `id` property. */
 // biome-ignore lint/suspicious/noExplicitAny: Data type is unknown at store level.
-const defaultGetEntityId: GetEntityId = (item: any) => item.id as EntityId;
+export const defaultGetEntityId: GetEntityId = (item: any) =>
+  item.id as EntityId;
 
 /**
  * State for coffin corner selection and hover.

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/store.ts
@@ -28,7 +28,18 @@ import type { CoffinCornerEvent, EntityId } from './types';
 // biome-ignore lint/suspicious/noExplicitAny: Data type is unknown at store level.
 type GetEntityId = (item: any) => EntityId;
 
-/** Default accessor — assumes the data item has an `id` property. */
+/**
+ * Default entity-ID accessor. Reads `item.id` directly.
+ *
+ * Exported so consumers can reference the same fallback that `useCoffinCorner`
+ * uses when no custom `getEntityId` option is passed.
+ *
+ * @example
+ * ```typescript
+ * // Use when building a custom hook that mirrors useCoffinCorner's fallback.
+ * const accessor = options?.getEntityId ?? defaultGetEntityId;
+ * ```
+ */
 // biome-ignore lint/suspicious/noExplicitAny: Data type is unknown at store level.
 export const defaultGetEntityId: GetEntityId = (item: any) =>
   item.id as EntityId;
@@ -44,7 +55,29 @@ export const defaultGetEntityId: GetEntityId = (item: any) =>
 
 const layerRegistry = new Map<UniqueId, Map<string, GetEntityId>>();
 
-/** Register (or update) a layer's entity-id accessor. Non-reactive. */
+/**
+ * Register (or update) a layer's entity-id accessor so that coffin corner
+ * bus handlers can resolve picked entities on click/hover.
+ *
+ * Writes to a plain module-level Map — intentionally non-reactive. Calling
+ * this during a React mount cycle does NOT trigger store subscribers and
+ * will NOT cause sibling components to re-render.
+ *
+ * Most consumers should call `useCoffinCorner`, which invokes this
+ * internally. Use the raw function only when building a custom hook or
+ * non-React integration.
+ *
+ * @param mapId - The BaseMap instance owning this layer.
+ * @param layerId - The deck.gl layer ID to associate the accessor with.
+ * @param getEntityId - Extracts an entity ID from a picked data item.
+ *
+ * @example
+ * ```typescript
+ * registerCoffinCornerLayer(mapId, 'klv-tracks', (item) => item.properties.id);
+ * // ...later, when tearing down:
+ * unregisterCoffinCornerLayer(mapId, 'klv-tracks');
+ * ```
+ */
 export function registerCoffinCornerLayer(
   mapId: UniqueId,
   layerId: string,
@@ -58,7 +91,23 @@ export function registerCoffinCornerLayer(
   byLayer.set(layerId, getEntityId);
 }
 
-/** Remove a layer's registration. Non-reactive. */
+/**
+ * Remove a layer's coffin-corner registration. After this call, bus handlers
+ * will ignore clicks and hovers on this layer until it is registered again.
+ *
+ * Non-reactive — does not notify store subscribers.
+ *
+ * @param mapId - The BaseMap instance owning this layer.
+ * @param layerId - The deck.gl layer ID to unregister.
+ *
+ * @example
+ * ```typescript
+ * useEffect(() => {
+ *   registerCoffinCornerLayer(mapId, layerId, getEntityId);
+ *   return () => unregisterCoffinCornerLayer(mapId, layerId);
+ * }, [mapId, layerId, getEntityId]);
+ * ```
+ */
 export function unregisterCoffinCornerLayer(
   mapId: UniqueId,
   layerId: string,
@@ -69,15 +118,10 @@ export function unregisterCoffinCornerLayer(
   if (byLayer.size === 0) layerRegistry.delete(mapId);
 }
 
-function getRegisteredAccessor(
+function getRegisteredLayers(
   mapId: UniqueId,
-  layerId: string,
-): GetEntityId | undefined {
-  return layerRegistry.get(mapId)?.get(layerId);
-}
-
-function getRegisteredLayerIds(mapId: UniqueId): Iterable<string> {
-  return layerRegistry.get(mapId)?.keys() ?? [];
+): Map<string, GetEntityId> | undefined {
+  return layerRegistry.get(mapId);
 }
 
 /**
@@ -93,12 +137,13 @@ type LayerState = {
 
 /**
  * State for coffin corner - manages multiple layers per map.
+ * The owning mapId is supplied to actions/bus via closure (see createMapStore)
+ * rather than carried in state, so it can't be accidentally unset or asserted
+ * with a type lie.
  */
 type CoffinCornerState = {
   /** Map of layerId -> layer state */
   layers: Map<string, LayerState>;
-  /** Map ID for filtering map bus events */
-  mapId: UniqueId;
 };
 
 /**
@@ -114,50 +159,58 @@ type CoffinCornerActions = {
 const coffinCornerEventBus = Broadcast.getInstance<CoffinCornerEvent>();
 const mapEventBus = Broadcast.getInstance<MapEventType>();
 
-/**
- * Coffin corner store - manages selection and hover state per map instance.
- *
- * Subscribes to map bus events for click/hover interactions and translates
- * them into coffin corner domain events. The hook only needs to pass the
- * layer ID — all subscription management lives here.
- *
- * @example
- * ```tsx
- * const { state, setSelectedId, deselect } = coffinCornerStore.use(mapId);
- * ```
- */
+/** Shared sentinel returned by readLayer when a layer has no state entry yet. */
+const EMPTY_LAYER: LayerState = Object.freeze({
+  selectedId: undefined,
+  hoveredId: undefined,
+}) as LayerState;
+
 /**
  * Get or synthesize an ephemeral layer state entry. Does NOT write to state.
  */
 function readLayer(state: CoffinCornerState, layerId: string): LayerState {
-  return (
-    state.layers.get(layerId) ?? {
-      selectedId: undefined,
-      hoveredId: undefined,
-    }
-  );
+  return state.layers.get(layerId) ?? EMPTY_LAYER;
 }
 
+/**
+ * Coffin corner store — manages selection and hover state per map instance,
+ * keyed by layer ID. One store instance per `BaseMap` via `createMapStore`.
+ *
+ * Subscribes to map bus events (click/hover) and translates them into coffin
+ * corner domain events. Layer registration (tracking which layers exist and
+ * their entity-ID accessors) lives in a non-reactive side-table — see
+ * `registerCoffinCornerLayer` — so new layers can be added without forcing a
+ * re-render in sibling components.
+ *
+ * Most consumers should use the `useCoffinCorner` hook, which subscribes and
+ * registers automatically. Use `coffinCornerStore` directly only for
+ * imperative access (tests, non-React integrations).
+ *
+ * @example
+ * ```tsx
+ * const { state, setSelectedId, deselect } = coffinCornerStore.use(mapId);
+ * const { selectedId, hoveredId } = state.layers.get('klv-tracks') ?? {};
+ * ```
+ */
 export const coffinCornerStore = createMapStore<
   CoffinCornerState,
   CoffinCornerActions
 >({
   defaultState: {
     layers: new Map(),
-    mapId: '' as UniqueId,
   },
 
   // Actions emit domain events rather than calling set() directly.
   // The bus subscriptions below translate events → state, ensuring
   // all state changes are observable by external subscribers.
-  actions: (_mapId, { get }) => ({
+  actions: (mapId, { get }) => ({
     setSelectedId: (layerId: string, id: EntityId | undefined) => {
       const state = get();
       const currentId = readLayer(state, layerId).selectedId;
 
       if (id == null && currentId != null) {
         coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-          mapId: state.mapId,
+          mapId,
           layerId,
           selectedId: undefined,
         });
@@ -169,7 +222,7 @@ export const coffinCornerStore = createMapStore<
         coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
           selectedId: id,
           layerId,
-          mapId: state.mapId,
+          mapId,
         });
 
         return;
@@ -178,20 +231,19 @@ export const coffinCornerStore = createMapStore<
 
     deselect: (layerId: string) => {
       coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-        mapId: get().mapId,
+        mapId,
         layerId,
         selectedId: undefined,
       });
     },
   }),
 
-  bus: (_mapId, { get, set }) => {
+  bus: (mapId, { get, set }) => {
     // Domain events → state
     const onSelected = coffinCornerEventBus.on(
       CoffinCornerEvents.SELECTED,
       (event) => {
-        const state = get();
-        if (event.payload.mapId !== state.mapId) {
+        if (event.payload.mapId !== mapId) {
           return;
         }
 
@@ -200,6 +252,7 @@ export const coffinCornerStore = createMapStore<
           return;
         }
 
+        const state = get();
         const layer = readLayer(state, layerId);
         if (layer.selectedId !== event.payload.selectedId) {
           const newLayer = { ...layer, selectedId: event.payload.selectedId };
@@ -211,8 +264,7 @@ export const coffinCornerStore = createMapStore<
     const onDeselected = coffinCornerEventBus.on(
       CoffinCornerEvents.DESELECTED,
       (event) => {
-        const state = get();
-        if (event.payload.mapId !== state.mapId) {
+        if (event.payload.mapId !== mapId) {
           return;
         }
 
@@ -221,6 +273,7 @@ export const coffinCornerStore = createMapStore<
           return;
         }
 
+        const state = get();
         const layer = state.layers.get(layerId);
         if (layer && layer.selectedId !== undefined) {
           const newLayer = { ...layer, selectedId: undefined };
@@ -232,8 +285,7 @@ export const coffinCornerStore = createMapStore<
     const onHovered = coffinCornerEventBus.on(
       CoffinCornerEvents.HOVERED,
       (event) => {
-        const state = get();
-        if (event.payload.mapId !== state.mapId) {
+        if (event.payload.mapId !== mapId) {
           return;
         }
 
@@ -242,6 +294,7 @@ export const coffinCornerStore = createMapStore<
           return;
         }
 
+        const state = get();
         const layer = readLayer(state, layerId);
         if (layer.hoveredId !== event.payload.hoveredId) {
           const newLayer = { ...layer, hoveredId: event.payload.hoveredId };
@@ -252,20 +305,20 @@ export const coffinCornerStore = createMapStore<
 
     // Map clicks → domain events
     const onClick = mapEventBus.on(MapEvents.click, (event: MapClickEvent) => {
-      const state = get();
-      if (event.payload.id !== state.mapId) {
+      if (event.payload.id !== mapId) {
         return;
       }
 
       const { info } = event.payload;
       const clickedLayerId = info.layerId;
+      const state = get();
 
       // If clicking empty space, deselect all currently-selected layers
       if (info.index === -1) {
         for (const [layerId, layerState] of state.layers.entries()) {
           if (layerState.selectedId !== undefined) {
             coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-              mapId: state.mapId,
+              mapId,
               layerId,
               selectedId: undefined,
             });
@@ -279,7 +332,7 @@ export const coffinCornerStore = createMapStore<
         return;
       }
 
-      const getEntityId = getRegisteredAccessor(state.mapId, clickedLayerId);
+      const getEntityId = getRegisteredLayers(mapId)?.get(clickedLayerId);
       if (!getEntityId) {
         return;
       }
@@ -290,7 +343,7 @@ export const coffinCornerStore = createMapStore<
 
         if (currentSelected === entityId) {
           coffinCornerEventBus.emit(CoffinCornerEvents.DESELECTED, {
-            mapId: state.mapId,
+            mapId,
             layerId: clickedLayerId,
             selectedId: undefined,
           });
@@ -298,7 +351,7 @@ export const coffinCornerStore = createMapStore<
           coffinCornerEventBus.emit(CoffinCornerEvents.SELECTED, {
             selectedId: entityId,
             layerId: clickedLayerId,
-            mapId: state.mapId,
+            mapId,
           });
         }
       }
@@ -306,20 +359,26 @@ export const coffinCornerStore = createMapStore<
 
     // Map hovers → domain events
     const onHover = mapEventBus.on(MapEvents.hover, (event: MapHoverEvent) => {
-      const state = get();
-      if (event.payload.id !== state.mapId) {
+      if (event.payload.id !== mapId) {
+        return;
+      }
+
+      const registeredLayers = getRegisteredLayers(mapId);
+      if (!registeredLayers) {
         return;
       }
 
       const { info } = event.payload;
       const hoveredLayerId = info.layerId;
+      const state = get();
 
       // Walk every registered layer so we can emit an "unhover" event
-      // for a layer when the pointer moves off of it.
-      for (const layerId of getRegisteredLayerIds(state.mapId)) {
-        const accessor = getRegisteredAccessor(state.mapId, layerId);
+      // for a layer when the pointer moves off of it. Iterate the registry's
+      // entries directly so we pay only one outer Map.get(mapId) per event
+      // (hover fires at ~60 fps during mouse movement).
+      for (const [layerId, accessor] of registeredLayers) {
         const hoveredId =
-          accessor && hoveredLayerId === layerId && info.object
+          hoveredLayerId === layerId && info.object
             ? accessor(info.object)
             : undefined;
 
@@ -328,7 +387,7 @@ export const coffinCornerStore = createMapStore<
           coffinCornerEventBus.emit(CoffinCornerEvents.HOVERED, {
             hoveredId,
             layerId,
-            mapId: state.mapId,
+            mapId,
           });
         }
       }

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/types.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/types.ts
@@ -59,22 +59,22 @@ export type CoffinCornerEventType =
 /** Unique identifier for an entity managed by the coffin corner extension. */
 export type EntityId = string | number;
 
-/** Payload emitted when an entity is selected. Contains the selected ID and map instance. */
+/** Payload emitted when an entity is selected. Contains the selected ID, layer ID, and map instance. */
 export type CoffinCornerSelectedEvent = Payload<
   typeof CoffinCornerEvents.SELECTED,
-  { selectedId: EntityId; mapId: UniqueId }
+  { selectedId: EntityId; layerId: string; mapId: UniqueId }
 >;
 
 /** Payload emitted when selection is cleared. */
 export type CoffinCornerDeselectedEvent = Payload<
   typeof CoffinCornerEvents.DESELECTED,
-  { mapId: UniqueId; selectedId: undefined }
+  { mapId: UniqueId; layerId: string; selectedId: undefined }
 >;
 
 /** Payload emitted when the hovered entity changes. `hoveredId` is undefined when hover ends. */
 export type CoffinCornerHoveredEvent = Payload<
   typeof CoffinCornerEvents.HOVERED,
-  { hoveredId?: EntityId; mapId: UniqueId }
+  { hoveredId?: EntityId; layerId: string; mapId: UniqueId }
 >;
 
 /** Union of all coffin corner event payloads for type-safe bus subscription. */

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
@@ -23,15 +23,17 @@ import type { CoffinCornerEvent } from './types';
 
 describe('useCoffinCorner', () => {
   let mapId: UniqueId;
+  let layerId: string;
   let bus: ReturnType<typeof Broadcast.getInstance<CoffinCornerEvent>>;
 
   beforeEach(() => {
     mapId = uuid();
+    layerId = 'symbols';
     bus = Broadcast.getInstance();
   });
 
   afterEach(() => {
-    clearSelection(mapId);
+    clearSelection(mapId, layerId);
   });
 
   describe('initial state', () => {
@@ -119,6 +121,7 @@ describe('useCoffinCorner', () => {
       act(() =>
         bus.emit(CoffinCornerEvents.HOVERED, {
           hoveredId: 'entity-5',
+          layerId: 'symbols',
           mapId,
         }),
       );
@@ -134,6 +137,7 @@ describe('useCoffinCorner', () => {
       act(() =>
         bus.emit(CoffinCornerEvents.HOVERED, {
           hoveredId: 'entity-5',
+          layerId: 'symbols',
           mapId,
         }),
       );
@@ -145,6 +149,7 @@ describe('useCoffinCorner', () => {
       act(() =>
         bus.emit(CoffinCornerEvents.HOVERED, {
           hoveredId: undefined,
+          layerId: 'symbols',
           mapId,
         }),
       );
@@ -176,8 +181,8 @@ describe('useCoffinCorner', () => {
         useCoffinCorner(mapId, 'symbols', { getEntityId: customAccessor }),
       );
 
-      const state = coffinCornerStore.get(mapId);
-      expect(state.getEntityId).toBe(customAccessor);
+      const layer = coffinCornerStore.get(mapId).layers.get(layerId);
+      expect(layer?.getEntityId).toBe(customAccessor);
     });
 
     it('should update getEntityId in store when option changes', () => {
@@ -188,11 +193,15 @@ describe('useCoffinCorner', () => {
         { initialProps: { getEntityId: accessor1 } },
       );
 
-      expect(coffinCornerStore.get(mapId).getEntityId).toBe(accessor1);
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.getEntityId,
+      ).toBe(accessor1);
 
       rerender({ getEntityId: accessor2 });
 
-      expect(coffinCornerStore.get(mapId).getEntityId).toBe(accessor2);
+      expect(
+        coffinCornerStore.get(mapId).layers.get(layerId)?.getEntityId,
+      ).toBe(accessor2);
     });
   });
 
@@ -203,11 +212,11 @@ describe('useCoffinCorner', () => {
         { initialProps: { layerId: 'layer-a' } },
       );
 
-      expect(coffinCornerStore.get(mapId).layerId).toBe('layer-a');
+      expect(coffinCornerStore.get(mapId).layers.has('layer-a')).toBe(true);
 
       rerender({ layerId: 'layer-b' });
 
-      expect(coffinCornerStore.get(mapId).layerId).toBe('layer-b');
+      expect(coffinCornerStore.get(mapId).layers.has('layer-b')).toBe(true);
     });
   });
 

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
@@ -198,14 +198,14 @@ describe('useCoffinCorner', () => {
   });
 
   describe('getEntityId option', () => {
-    it('uses custom getEntityId when resolving hovered entity from map hover events', async () => {
+    it('uses custom getEntityId when resolving hovered entity from map hover events', () => {
       const customAccessor = (item: { uid: string }) => item.uid;
       const mapBus = Broadcast.getInstance<MapEventType>();
       const { result } = renderHook(() =>
         useCoffinCorner(mapId, 'symbols', { getEntityId: customAccessor }),
       );
 
-      await act(async () => {
+      act(() => {
         mapBus.emit(
           MapEvents.hover,
           createHoverEvent(mapId, {
@@ -218,7 +218,7 @@ describe('useCoffinCorner', () => {
       expect(result.current.hoveredId).toBe('from-custom-accessor');
     });
 
-    it('uses the updated getEntityId after the option changes', async () => {
+    it('uses the updated getEntityId after the option changes', () => {
       const accessor1 = (item: { uid: string }) => item.uid;
       const accessor2 = (item: { code: string }) => item.code;
       const mapBus = Broadcast.getInstance<MapEventType>();
@@ -229,7 +229,7 @@ describe('useCoffinCorner', () => {
         },
       );
 
-      await act(async () => {
+      act(() => {
         mapBus.emit(
           MapEvents.hover,
           createHoverEvent(mapId, {
@@ -242,7 +242,7 @@ describe('useCoffinCorner', () => {
 
       rerender({ getEntityId: accessor2 as (item: unknown) => string });
 
-      await act(async () => {
+      act(() => {
         mapBus.emit(
           MapEvents.hover,
           createHoverEvent(mapId, {
@@ -256,7 +256,7 @@ describe('useCoffinCorner', () => {
   });
 
   describe('layerId changes', () => {
-    it('routes hover events to the currently-registered layer after a layerId change', async () => {
+    it('routes hover events to the currently-registered layer after a layerId change', () => {
       const mapBus = Broadcast.getInstance<MapEventType>();
       const { result, rerender } = renderHook(
         ({ layerId }) =>
@@ -267,7 +267,7 @@ describe('useCoffinCorner', () => {
       );
 
       // Hover on layer-a resolves through the current registration.
-      await act(async () => {
+      act(() => {
         mapBus.emit(
           MapEvents.hover,
           createHoverEvent(mapId, {
@@ -281,7 +281,7 @@ describe('useCoffinCorner', () => {
       rerender({ layerId: 'layer-b' });
 
       // After rerender, the hook watches layer-b and ignores hovers on layer-a.
-      await act(async () => {
+      act(() => {
         mapBus.emit(
           MapEvents.hover,
           createHoverEvent(mapId, {

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.test.tsx
@@ -15,11 +15,33 @@ import { uuid } from '@accelint/core';
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { clearSelection, coffinCornerStore } from './store';
+import { MapEvents } from '../../base-map/events';
+import { clearSelection } from './store';
 import { CoffinCornerEvents } from './types';
 import { useCoffinCorner } from './use-coffin-corner';
 import type { UniqueId } from '@accelint/core';
+import type { MapEventType } from '../../base-map/types';
 import type { CoffinCornerEvent } from './types';
+
+/** Minimal MapEvents.hover payload — only the fields the store reads. */
+function createHoverEvent(id: UniqueId, info: Record<string, unknown> = {}) {
+  return {
+    id,
+    info: {
+      index: 0,
+      picked: true,
+      x: 0,
+      y: 0,
+      coordinate: [0, 0],
+      pixel: [0, 0],
+      devicePixel: [0, 0],
+      pixelRatio: 1,
+      color: null,
+      ...info,
+    },
+    event: {} as never,
+  };
+}
 
 describe('useCoffinCorner', () => {
   let mapId: UniqueId;
@@ -166,6 +188,7 @@ describe('useCoffinCorner', () => {
       act(() =>
         bus.emit(CoffinCornerEvents.HOVERED, {
           hoveredId: 'entity-5',
+          layerId: 'symbols',
           mapId: otherMapId,
         }),
       );
@@ -175,48 +198,99 @@ describe('useCoffinCorner', () => {
   });
 
   describe('getEntityId option', () => {
-    it('should forward getEntityId to the store', () => {
+    it('uses custom getEntityId when resolving hovered entity from map hover events', async () => {
       const customAccessor = (item: { uid: string }) => item.uid;
-      renderHook(() =>
+      const mapBus = Broadcast.getInstance<MapEventType>();
+      const { result } = renderHook(() =>
         useCoffinCorner(mapId, 'symbols', { getEntityId: customAccessor }),
       );
 
-      const layer = coffinCornerStore.get(mapId).layers.get(layerId);
-      expect(layer?.getEntityId).toBe(customAccessor);
+      await act(async () => {
+        mapBus.emit(
+          MapEvents.hover,
+          createHoverEvent(mapId, {
+            layerId: 'symbols',
+            object: { uid: 'from-custom-accessor' },
+          }),
+        );
+      });
+
+      expect(result.current.hoveredId).toBe('from-custom-accessor');
     });
 
-    it('should update getEntityId in store when option changes', () => {
+    it('uses the updated getEntityId after the option changes', async () => {
       const accessor1 = (item: { uid: string }) => item.uid;
       const accessor2 = (item: { code: string }) => item.code;
-      const { rerender } = renderHook(
+      const mapBus = Broadcast.getInstance<MapEventType>();
+      const { result, rerender } = renderHook(
         ({ getEntityId }) => useCoffinCorner(mapId, 'symbols', { getEntityId }),
-        { initialProps: { getEntityId: accessor1 } },
+        {
+          initialProps: { getEntityId: accessor1 as (item: unknown) => string },
+        },
       );
 
-      expect(
-        coffinCornerStore.get(mapId).layers.get(layerId)?.getEntityId,
-      ).toBe(accessor1);
+      await act(async () => {
+        mapBus.emit(
+          MapEvents.hover,
+          createHoverEvent(mapId, {
+            layerId: 'symbols',
+            object: { uid: 'via-accessor1' },
+          }),
+        );
+      });
+      expect(result.current.hoveredId).toBe('via-accessor1');
 
-      rerender({ getEntityId: accessor2 });
+      rerender({ getEntityId: accessor2 as (item: unknown) => string });
 
-      expect(
-        coffinCornerStore.get(mapId).layers.get(layerId)?.getEntityId,
-      ).toBe(accessor2);
+      await act(async () => {
+        mapBus.emit(
+          MapEvents.hover,
+          createHoverEvent(mapId, {
+            layerId: 'symbols',
+            object: { code: 'via-accessor2' },
+          }),
+        );
+      });
+      expect(result.current.hoveredId).toBe('via-accessor2');
     });
   });
 
   describe('layerId changes', () => {
-    it('should update layerId in store when prop changes', () => {
-      const { rerender } = renderHook(
-        ({ layerId }) => useCoffinCorner(mapId, layerId),
+    it('routes hover events to the currently-registered layer after a layerId change', async () => {
+      const mapBus = Broadcast.getInstance<MapEventType>();
+      const { result, rerender } = renderHook(
+        ({ layerId }) =>
+          useCoffinCorner(mapId, layerId, {
+            getEntityId: (item: { id: string }) => item.id,
+          }),
         { initialProps: { layerId: 'layer-a' } },
       );
 
-      expect(coffinCornerStore.get(mapId).layers.has('layer-a')).toBe(true);
+      // Hover on layer-a resolves through the current registration.
+      await act(async () => {
+        mapBus.emit(
+          MapEvents.hover,
+          createHoverEvent(mapId, {
+            layerId: 'layer-a',
+            object: { id: 'on-a' },
+          }),
+        );
+      });
+      expect(result.current.hoveredId).toBe('on-a');
 
       rerender({ layerId: 'layer-b' });
 
-      expect(coffinCornerStore.get(mapId).layers.has('layer-b')).toBe(true);
+      // After rerender, the hook watches layer-b and ignores hovers on layer-a.
+      await act(async () => {
+        mapBus.emit(
+          MapEvents.hover,
+          createHoverEvent(mapId, {
+            layerId: 'layer-b',
+            object: { id: 'on-b' },
+          }),
+        );
+      });
+      expect(result.current.hoveredId).toBe('on-b');
     });
   });
 

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
@@ -13,7 +13,12 @@
 'use client';
 
 import { useEffect } from 'react';
-import { coffinCornerStore, defaultGetEntityId } from './store';
+import {
+  coffinCornerStore,
+  defaultGetEntityId,
+  registerCoffinCornerLayer,
+  unregisterCoffinCornerLayer,
+} from './store';
 import type { UniqueId } from '@accelint/core';
 import type { EntityId } from './types';
 
@@ -86,40 +91,36 @@ export function useCoffinCorner(
   layerId: string,
   options?: UseCoffinCornerOptions,
 ): UseCoffinCornerReturn {
-  const getEntityId = options?.getEntityId;
+  const getEntityId = options?.getEntityId ?? defaultGetEntityId;
 
-  // Seed layerId and getEntityId into the store BEFORE use() subscribes and
-  // sets up the bus. setInitialState writes directly without calling notify(),
-  // so no rerender is triggered. This makes the useEffects below no-ops on
-  // first mount, preventing the startup rerender that broke deck.gl/maplibre sync.
+  // Seed the map store on first creation with an empty layers Map so that
+  // coffinCornerStore.use() has something to subscribe to. Once seeded, we
+  // never mutate store state from this hook — registration (tracking which
+  // layers exist and their entity-id accessors) lives in a non-reactive
+  // module-level side table so it can't trigger useSyncExternalStore
+  // snapshot changes that desync deck.gl's viewport from maplibre's on pan/zoom.
   if (!coffinCornerStore.exists(mapId)) {
     coffinCornerStore.setInitialState(mapId, {
-      selectedId: undefined,
-      hoveredId: undefined,
-      layerId,
-      getEntityId: getEntityId ?? defaultGetEntityId,
+      layers: new Map(),
+      mapId,
     });
   }
 
-  const { state, setSelectedId, deselect, setLayerId, setGetEntityId } =
-    coffinCornerStore.use(mapId);
+  const { state, setSelectedId, deselect } = coffinCornerStore.use(mapId);
+  const layerState = state.layers.get(layerId);
 
-  // Still needed to handle layerId/getEntityId changes after initial mount.
-  // Guarded by equality checks in the store actions, so no-ops when values are unchanged.
+  // Non-reactive registration. Plain Map writes — invisible to React.
   useEffect(() => {
-    setLayerId(layerId);
-  }, [setLayerId, layerId]);
-
-  useEffect(() => {
-    if (getEntityId) {
-      setGetEntityId(getEntityId);
-    }
-  }, [setGetEntityId, getEntityId]);
+    registerCoffinCornerLayer(mapId, layerId, getEntityId);
+    return () => {
+      unregisterCoffinCornerLayer(mapId, layerId);
+    };
+  }, [mapId, layerId, getEntityId]);
 
   return {
-    selectedId: state.selectedId,
-    hoveredId: state.hoveredId,
-    setSelectedId,
-    deselect,
+    selectedId: layerState?.selectedId,
+    hoveredId: layerState?.hoveredId,
+    setSelectedId: (id: EntityId | undefined) => setSelectedId(layerId, id),
+    deselect: () => deselect(layerId),
   };
 }

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
@@ -12,7 +12,7 @@
 
 'use client';
 
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   coffinCornerStore,
   defaultGetEntityId,
@@ -102,7 +102,6 @@ export function useCoffinCorner(
   if (!coffinCornerStore.exists(mapId)) {
     coffinCornerStore.setInitialState(mapId, {
       layers: new Map(),
-      mapId,
     });
   }
 
@@ -117,10 +116,19 @@ export function useCoffinCorner(
     };
   }, [mapId, layerId, getEntityId]);
 
+  const boundSetSelectedId = useCallback(
+    (id: EntityId | undefined) => setSelectedId(layerId, id),
+    [setSelectedId, layerId],
+  );
+  const boundDeselect = useCallback(
+    () => deselect(layerId),
+    [deselect, layerId],
+  );
+
   return {
     selectedId: layerState?.selectedId,
     hoveredId: layerState?.hoveredId,
-    setSelectedId: (id: EntityId | undefined) => setSelectedId(layerId, id),
-    deselect: () => deselect(layerId),
+    setSelectedId: boundSetSelectedId,
+    deselect: boundDeselect,
   };
 }

--- a/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
+++ b/packages/map-toolkit/src/deckgl/extensions/coffin-corner/use-coffin-corner.ts
@@ -13,7 +13,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { coffinCornerStore } from './store';
+import { coffinCornerStore, defaultGetEntityId } from './store';
 import type { UniqueId } from '@accelint/core';
 import type { EntityId } from './types';
 
@@ -86,17 +86,29 @@ export function useCoffinCorner(
   layerId: string,
   options?: UseCoffinCornerOptions,
 ): UseCoffinCornerReturn {
+  const getEntityId = options?.getEntityId;
+
+  // Seed layerId and getEntityId into the store BEFORE use() subscribes and
+  // sets up the bus. setInitialState writes directly without calling notify(),
+  // so no rerender is triggered. This makes the useEffects below no-ops on
+  // first mount, preventing the startup rerender that broke deck.gl/maplibre sync.
+  if (!coffinCornerStore.exists(mapId)) {
+    coffinCornerStore.setInitialState(mapId, {
+      selectedId: undefined,
+      hoveredId: undefined,
+      layerId,
+      getEntityId: getEntityId ?? defaultGetEntityId,
+    });
+  }
+
   const { state, setSelectedId, deselect, setLayerId, setGetEntityId } =
     coffinCornerStore.use(mapId);
 
-  // Unlike a CompositeLayer, CoffinCornerExtension is a shader-only plugin
-  // with no picking handlers. The store must filter raw map bus events by
-  // layerId to know which clicks/hovers belong to this extension's layer.
+  // Still needed to handle layerId/getEntityId changes after initial mount.
+  // Guarded by equality checks in the store actions, so no-ops when values are unchanged.
   useEffect(() => {
     setLayerId(layerId);
   }, [setLayerId, layerId]);
-
-  const getEntityId = options?.getEntityId;
 
   useEffect(() => {
     if (getEntityId) {


### PR DESCRIPTION
@Peechiz reported a bug with useCoffinCorner that mirrored the one found in DrawShapeLayer where a useEffect was triggering a rerender during initial mount, which broke deckgl and MapLibre's connection such that when you update the viewport after initial render, the coffin corners show up in the marker's initial location, not the updated one.

The root cause was that layer registration (layerId, getEntityId) was stored in reactive state. When a second layer registered, the shared state reference changed, triggering useSyncExternalStore's post-commit snapshot check and scheduling a mid-mount re-render that desynced the viewports.

This work moves layer registration to a non-reactive module-level registry (plain Map writes invisible to React) and refactors the store to be multi-layer aware, holding only `selectedId` and `hoveredId` per layer. The store now updates exclusively from user interaction through the map bus.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

- Pull ngc2 and checkout `feat/replace-selection-store`
- `pnpm build` this branch in standard-toolkit
- file-link the locally built map-toolkit within the ngc2 `package.json` and `pnpm i`
- `pnpm dev` and hover an entity to see the proper behavior, pan the map using your arrow keys, see the proper behavior still.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [x] Ideation / brainstorming
- [x] Documentation
- [x] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
