### PR TITLE
feat: added pinning feature to FloatingCard

### DIFF
--- a/.changeset/quiet-pins-float.md
+++ b/.changeset/quiet-pins-float.md
@@ -2,4 +2,11 @@
 "@accelint/design-toolkit": minor
 ---
 
-Add floating card pinning feature. Cards can be pinned to disable dragging via a `'pin'` header action. Includes `togglePinCard` and `isPinned` on the floating card context, and a new `FloatingCardHeaderAction` type supporting `'pin'` alongside existing `'divider'` and custom button actions.
+Add floating card pinning feature and new placement props.
+
+- Cards can be pinned to disable dragging via a `'pin'` header action
+- `togglePinCard` and `isPinned` added to the floating card context
+- New `FloatingCardHeaderAction` type supports `'pin'` alongside existing `'divider'` and custom button actions
+- `FloatingCardProvider` accepts `initialPinned` to pre-pin cards at mount time
+- `FloatingCard` accepts `initialPosition` (`{ x, y }`) to set the starting coordinates of the panel
+- `FloatingCard` accepts `initialDimensions` (`{ width, height }`) to set the starting size of the panel (defaults to `300 × 400`)

--- a/.changeset/quiet-pins-float.md
+++ b/.changeset/quiet-pins-float.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": minor
+---
+
+Add floating card pinning feature. Cards can be pinned to disable dragging via a `'pin'` header action. Includes `togglePinCard` and `isPinned` on the floating card context, and a new `FloatingCardHeaderAction` type supporting `'pin'` alongside existing `'divider'` and custom button actions.

--- a/packages/design-toolkit/src/components/floating-card/context.tsx
+++ b/packages/design-toolkit/src/components/floating-card/context.tsx
@@ -40,6 +40,9 @@ export type FloatingCardContextValue = {
   /** Checks if a floating card is currently pinned */
   isPinned: (id: UniqueId) => boolean;
 
+  /** Subscribes to pin state changes; returns an unsubscribe function */
+  subscribeToPinState: (callback: () => void) => () => void;
+
   /** Dockview API instance, null until FloatingCardProvider's onReady fires */
   api: DockviewApi | null;
 };

--- a/packages/design-toolkit/src/components/floating-card/context.tsx
+++ b/packages/design-toolkit/src/components/floating-card/context.tsx
@@ -15,22 +15,58 @@ import { createContext, useContext } from 'react';
 import type { UniqueId } from '@accelint/core/utility/uuid';
 import type { DockviewApi } from 'dockview-react';
 
+/**
+ * Context value providing floating card management functionality.
+ *
+ * @remarks
+ * Exposed via FloatingCardProvider to child components. Use useFloatingCard() hook to access.
+ */
 export type FloatingCardContextValue = {
+  /** Registry mapping card IDs to their rendered DOM containers */
   cards: Record<UniqueId, HTMLDivElement>;
+
+  /** Registers a DOM ref for a card container after it mounts */
   addRef: (id: UniqueId, ref: HTMLDivElement | null) => void;
+
+  /** Unregisters a card's DOM ref when it's removed */
   removeRef: (view: UniqueId) => void;
+
+  /** Programmatically closes a floating card by ID */
   closeCard: (id: UniqueId) => void;
+
+  /** Toggles pin state for a floating card, disabling drag when pinned */
+  togglePinCard: (id: UniqueId) => void;
+
+  /** Checks if a floating card is currently pinned */
+  isPinned: (id: UniqueId) => boolean;
+
+  /** Dockview API instance, null until FloatingCardProvider's onReady fires */
   api: DockviewApi | null;
 };
 
 export const FloatingCardContext =
   createContext<FloatingCardContextValue | null>(null);
 /**
- * Hook to access the floating card context.
- * Must be used within a FloatingCardProvider.
+ * Hook to access floating card management functionality.
  *
+ * Provides access to card registry, ref management, and programmatic control
+ * over opening, closing, and pinning floating cards.
+ *
+ * @returns Context value with card management methods and state.
  * @throws {Error} If used outside of a FloatingCardProvider.
- * @returns The floating card context value.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { closeCard, togglePinCard } = useFloatingCard();
+ *
+ *   return (
+ *     <button onClick={() => closeCard('my-card-id' as UniqueId)}>
+ *       Close Card
+ *     </button>
+ *   );
+ * }
+ * ```
  */
 export function useFloatingCard(): FloatingCardContextValue {
   const context = useContext(FloatingCardContext);

--- a/packages/design-toolkit/src/components/floating-card/floating-card.stories.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.stories.tsx
@@ -64,7 +64,7 @@ export const WithHeaderActions: Story = {
           headerActions={[
             {
               icon: <span className='text-lg'>⚙️</span>,
-              onPress: () => alert('Action clicked'),
+              onClick: () => alert('Action clicked'),
             },
           ]}
         >
@@ -156,21 +156,21 @@ export const WithHeaderActionDividers: Story = {
           headerActions={[
             {
               icon: <span>📌</span>,
-              onPress: () => alert('Pin clicked'),
+              onClick: () => alert('Pin clicked'),
             },
             {
               icon: <span className='text-lg'>🔗</span>,
-              onPress: () => alert('Share clicked'),
+              onClick: () => alert('Share clicked'),
             },
             'divider',
             {
               icon: <span className='text-lg'>⚙️</span>,
-              onPress: () => alert('Settings clicked'),
+              onClick: () => alert('Settings clicked'),
             },
             'divider',
             {
               icon: <span className='text-lg'>🗑️</span>,
-              onPress: () => alert('Delete clicked'),
+              onClick: () => alert('Delete clicked'),
             },
           ]}
         >
@@ -193,7 +193,7 @@ export const ControlledVisibility: Story = {
       <div className='relative h-800 w-600 p-l outline outline-info-bold'>
         <div className='absolute top-0 left-0 z-50 p-m'>
           <Button
-            onPress={() => setIsOpen(!isOpen)}
+            onClick={() => setIsOpen(!isOpen)}
             className='rounded border border-interactive-default bg-base-surface px-m py-s font-semibold text-sm hover:bg-base-surface-hover'
           >
             {isOpen ? 'Close Card' : 'Open Card'}
@@ -228,6 +228,32 @@ export const WithScrollableContent: Story = {
                 </p>
               ))}
             </div>
+          </FloatingCard>
+        </FloatingCardProvider>
+      </div>
+    );
+  },
+};
+
+function PinnableCardContent() {
+  return (
+    <div className='flex h-full flex-col items-center justify-center gap-m self-stretch rounded-medium bg-base-surface p-m outline outline-dashed outline-1 outline-interactive-hover'>
+      <div className='font-semibold text-sm'>Pinnable Card</div>
+      <p className='text-base-text-secondary text-xs'>
+        Click the pin button in the header — dragging will be disabled while
+        pinned.
+      </p>
+    </div>
+  );
+}
+
+export const Pinnable: Story = {
+  render: (args) => {
+    return (
+      <div className='relative h-800 w-600 p-l outline outline-info-bold'>
+        <FloatingCardProvider icon={<Placeholder />} headerActions={['pin']}>
+          <FloatingCard id={args.id} title='Pinnable Card'>
+            <PinnableCardContent />
           </FloatingCard>
         </FloatingCardProvider>
       </div>

--- a/packages/design-toolkit/src/components/floating-card/floating-card.stories.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.stories.tsx
@@ -220,7 +220,7 @@ export const WithScrollableContent: Story = {
     return (
       <div className='relative h-800 w-600 p-l outline outline-info-bold'>
         <FloatingCardProvider>
-          <FloatingCard id={args.id} title={args.title}>
+          <FloatingCard id={panelIds.a} title={args.title}>
             <div className='flex h-full flex-col items-center justify-start gap-m self-stretch overflow-auto rounded-medium p-m'>
               {Array.from({ length: 20 }, (_, i) => (
                 <p key={i} className='text-sm'>
@@ -248,11 +248,17 @@ function PinnableCardContent() {
 }
 
 export const Pinnable: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <div className='relative h-800 w-600 p-l outline outline-info-bold'>
-        <FloatingCardProvider icon={<Placeholder />} headerActions={['pin']}>
-          <FloatingCard id={args.id} title='Pinnable Card'>
+        <FloatingCardProvider
+          icon={<Placeholder />}
+          headerActions={(id) => (id === panelIds.a ? ['pin'] : [])}
+        >
+          <FloatingCard id={panelIds.a} title='Pinnable Card'>
+            <PinnableCardContent />
+          </FloatingCard>
+          <FloatingCard id={panelIds.b} title='Pinnable Card'>
             <PinnableCardContent />
           </FloatingCard>
         </FloatingCardProvider>

--- a/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
@@ -120,6 +120,8 @@ describe('FloatingCardContext defaults', () => {
           addRef: () => undefined,
           removeRef: () => undefined,
           closeCard: () => undefined,
+          togglePinCard: () => undefined,
+          isPinned: () => false,
           api: null,
         }}
       >
@@ -430,6 +432,8 @@ describe('FloatingCardContainer', () => {
           addRef,
           removeRef: vi.fn(),
           closeCard: vi.fn(),
+          togglePinCard: vi.fn(),
+          isPinned: () => false,
           api: null,
         }}
       >
@@ -519,7 +523,19 @@ describe('header adapters', () => {
       capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
 
     const { getAllByRole } = render(
-      <RightAdapter {...makeMockAdapterProps(makeMockActivePanel())} />,
+      <FloatingCardContext.Provider
+        value={{
+          cards: {},
+          addRef: () => undefined,
+          removeRef: () => undefined,
+          closeCard: () => undefined,
+          togglePinCard: () => undefined,
+          isPinned: () => false,
+          api: null,
+        }}
+      >
+        <RightAdapter {...makeMockAdapterProps(makeMockActivePanel())} />
+      </FloatingCardContext.Provider>,
     );
 
     // 3 action buttons + 1 always-present close button
@@ -588,6 +604,8 @@ describe('FloatingCard', () => {
       addRef: vi.fn(),
       removeRef: vi.fn(),
       closeCard: vi.fn(),
+      togglePinCard: vi.fn(),
+      isPinned: () => false,
       api,
     };
   }
@@ -923,5 +941,107 @@ describe('multiple FloatingCardProvider instances', () => {
 
     expect(latest1().cards['card-in-provider-1' as UniqueId]).toBe(div);
     expect(latest2().cards['card-in-provider-1' as UniqueId]).toBeUndefined();
+  });
+});
+
+describe('pin functionality', () => {
+  it('should expose togglePinCard and isPinned via context', () => {
+    const { spy, latest } = captureContext();
+
+    render(
+      <FloatingCardProvider>
+        <ContextReader onContext={spy} />
+      </FloatingCardProvider>,
+    );
+
+    expect(typeof latest().togglePinCard).toBe('function');
+    expect(typeof latest().isPinned).toBe('function');
+  });
+
+  it('should toggle a card between pinned and unpinned', () => {
+    const { spy, latest } = captureContext();
+
+    render(
+      <FloatingCardProvider>
+        <ContextReader onContext={spy} />
+      </FloatingCardProvider>,
+    );
+
+    expect(latest().isPinned('card-pin' as UniqueId)).toBe(false);
+
+    act(() => {
+      latest().togglePinCard('card-pin' as UniqueId);
+    });
+
+    expect(latest().isPinned('card-pin' as UniqueId)).toBe(true);
+
+    act(() => {
+      latest().togglePinCard('card-pin' as UniqueId);
+    });
+
+    expect(latest().isPinned('card-pin' as UniqueId)).toBe(false);
+  });
+
+  it('should clear pinned state when a card is removed via removeRef', () => {
+    const { spy, latest } = captureContext();
+
+    render(
+      <FloatingCardProvider>
+        <ContextReader onContext={spy} />
+      </FloatingCardProvider>,
+    );
+
+    act(() => {
+      latest().togglePinCard('card-remove' as UniqueId);
+    });
+
+    expect(latest().isPinned('card-remove' as UniqueId)).toBe(true);
+
+    act(() => {
+      latest().removeRef('card-remove' as UniqueId);
+    });
+
+    expect(latest().isPinned('card-remove' as UniqueId)).toBe(false);
+  });
+
+  it('should clear pinned state when a panel is removed via dockview', () => {
+    const { spy, latest } = captureContext();
+    const mockApi = createMockApi();
+    let removePanelCallback: OnDidRemovePanelCallback | undefined;
+
+    mockApi.onDidRemovePanel.mockImplementation(
+      (cb: OnDidRemovePanelCallback) => {
+        removePanelCallback = cb;
+        return { dispose: vi.fn() };
+      },
+    );
+
+    const { rerender } = render(
+      <FloatingCardProvider>
+        <ContextReader onContext={spy} />
+      </FloatingCardProvider>,
+    );
+
+    act(() => {
+      triggerReady(mockApi);
+    });
+
+    rerender(
+      <FloatingCardProvider>
+        <ContextReader onContext={spy} />
+      </FloatingCardProvider>,
+    );
+
+    act(() => {
+      latest().togglePinCard('pinned-removed' as UniqueId);
+    });
+
+    expect(latest().isPinned('pinned-removed' as UniqueId)).toBe(true);
+
+    act(() => {
+      removePanelCallback?.({ id: 'pinned-removed' });
+    });
+
+    expect(latest().isPinned('pinned-removed' as UniqueId)).toBe(false);
   });
 });

--- a/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
@@ -862,6 +862,139 @@ describe('FloatingCard', () => {
     });
   });
 
+  describe('initialDimensions and initialPosition', () => {
+    it('should pass default dimensions into the floating option when initialDimensions is omitted', () => {
+      const { api } = makeEmptyApi();
+      const div = document.createElement('div');
+
+      render(
+        <FloatingCardContext.Provider
+          value={makeContextValue(api, { 'default-dim-card': div })}
+        >
+          <FloatingCard id={'default-dim-card' as UniqueId} isOpen>
+            content
+          </FloatingCard>
+        </FloatingCardContext.Provider>,
+      );
+
+      expect(
+        (api as unknown as { addPanel: ReturnType<typeof vi.fn> }).addPanel,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          floating: expect.objectContaining({ width: 300, height: 400 }),
+        }),
+      );
+    });
+
+    it('should pass custom initialDimensions into the floating option', () => {
+      const { api } = makeEmptyApi();
+      const div = document.createElement('div');
+
+      render(
+        <FloatingCardContext.Provider
+          value={makeContextValue(api, { 'custom-dim-card': div })}
+        >
+          <FloatingCard
+            id={'custom-dim-card' as UniqueId}
+            isOpen
+            initialDimensions={{ width: 500, height: 600 }}
+          >
+            content
+          </FloatingCard>
+        </FloatingCardContext.Provider>,
+      );
+
+      expect(
+        (api as unknown as { addPanel: ReturnType<typeof vi.fn> }).addPanel,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          floating: expect.objectContaining({ width: 500, height: 600 }),
+        }),
+      );
+    });
+
+    it('should pass initialPosition x and y into the floating option when provided', () => {
+      const { api } = makeEmptyApi();
+      const div = document.createElement('div');
+
+      render(
+        <FloatingCardContext.Provider
+          value={makeContextValue(api, { 'pos-card': div })}
+        >
+          <FloatingCard
+            id={'pos-card' as UniqueId}
+            isOpen
+            initialPosition={{ x: 100, y: 200 }}
+          >
+            content
+          </FloatingCard>
+        </FloatingCardContext.Provider>,
+      );
+
+      expect(
+        (api as unknown as { addPanel: ReturnType<typeof vi.fn> }).addPanel,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          floating: expect.objectContaining({ x: 100, y: 200 }),
+        }),
+      );
+    });
+
+    it('should combine initialDimensions and initialPosition in the floating option', () => {
+      const { api } = makeEmptyApi();
+      const div = document.createElement('div');
+
+      render(
+        <FloatingCardContext.Provider
+          value={makeContextValue(api, { 'combined-card': div })}
+        >
+          <FloatingCard
+            id={'combined-card' as UniqueId}
+            isOpen
+            initialDimensions={{ width: 350, height: 450 }}
+            initialPosition={{ x: 50, y: 75 }}
+          >
+            content
+          </FloatingCard>
+        </FloatingCardContext.Provider>,
+      );
+
+      expect(
+        (api as unknown as { addPanel: ReturnType<typeof vi.fn> }).addPanel,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          floating: { width: 350, height: 450, x: 50, y: 75 },
+        }),
+      );
+    });
+
+    it('should not include x or y in the floating option when initialPosition is omitted', () => {
+      const { api } = makeEmptyApi();
+      const div = document.createElement('div');
+
+      render(
+        <FloatingCardContext.Provider
+          value={makeContextValue(api, { 'no-pos-card': div })}
+        >
+          <FloatingCard id={'no-pos-card' as UniqueId} isOpen>
+            content
+          </FloatingCard>
+        </FloatingCardContext.Provider>,
+      );
+
+      const addPanel = (
+        api as unknown as { addPanel: ReturnType<typeof vi.fn> }
+      ).addPanel;
+      const floating = addPanel.mock.calls[0][0].floating as Record<
+        string,
+        unknown
+      >;
+
+      expect(floating).not.toHaveProperty('x');
+      expect(floating).not.toHaveProperty('y');
+    });
+  });
+
   describe('unmount behavior', () => {
     it('should not call panel.api.close() when the component unmounts', () => {
       // The first useEffect has no cleanup — close is the provider\'s responsibility
@@ -1039,6 +1172,99 @@ describe('pin functionality', () => {
     });
 
     expect(pinButton).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  describe('initialPinned', () => {
+    it('should expose initially pinned cards via isPinned in context', () => {
+      const { spy, latest } = captureContext();
+
+      render(
+        <FloatingCardProvider initialPinned={['pre-pinned' as UniqueId]}>
+          <ContextReader onContext={spy} />
+        </FloatingCardProvider>,
+      );
+
+      expect(latest().isPinned('pre-pinned' as UniqueId)).toBe(true);
+      expect(latest().isPinned('not-listed' as UniqueId)).toBe(false);
+    });
+
+    it('should render the pin button as pressed for an initially pinned card', () => {
+      render(
+        <FloatingCardProvider
+          headerActions={['pin']}
+          initialPinned={['pinned-at-start' as UniqueId]}
+        >
+          <div />
+        </FloatingCardProvider>,
+      );
+
+      const RightAdapter =
+        capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
+
+      render(
+        <RightAdapter
+          {...makeMockAdapterProps(makeMockActivePanel('pinned-at-start'))}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    it('should render the pin button as unpressed for a card not in initialPinned', () => {
+      render(
+        <FloatingCardProvider
+          headerActions={['pin']}
+          initialPinned={['other-card' as UniqueId]}
+        >
+          <div />
+        </FloatingCardProvider>,
+      );
+
+      const RightAdapter =
+        capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
+
+      render(
+        <RightAdapter
+          {...makeMockAdapterProps(makeMockActivePanel('not-in-initial'))}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /pin/i })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('should allow toggling an initially pinned card to unpinned', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <FloatingCardProvider
+          headerActions={['pin']}
+          initialPinned={['toggle-initial' as UniqueId]}
+        >
+          <div />
+        </FloatingCardProvider>,
+      );
+
+      const RightAdapter =
+        capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
+
+      render(
+        <RightAdapter
+          {...makeMockAdapterProps(makeMockActivePanel('toggle-initial'))}
+        />,
+      );
+
+      const pinButton = screen.getByRole('button', { name: /pin/i });
+      expect(pinButton).toHaveAttribute('aria-pressed', 'true');
+
+      await user.click(pinButton);
+      expect(pinButton).toHaveAttribute('aria-pressed', 'false');
+    });
   });
 
   it('should release pin when card is removed via dockview', async () => {

--- a/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
@@ -968,7 +968,7 @@ describe('FloatingCard', () => {
       );
     });
 
-    it('should not include x or y in the floating option when initialPosition is omitted', () => {
+    it('should include x and y as undefined in the floating option when initialPosition is omitted', () => {
       const { api } = makeEmptyApi();
       const div = document.createElement('div');
 
@@ -985,13 +985,13 @@ describe('FloatingCard', () => {
       const addPanel = (
         api as unknown as { addPanel: ReturnType<typeof vi.fn> }
       ).addPanel;
-      const floating = addPanel.mock.calls[0][0].floating as Record<
+      const floating = addPanel.mock.calls[0]?.[0].floating as Record<
         string,
         unknown
       >;
 
-      expect(floating).not.toHaveProperty('x');
-      expect(floating).not.toHaveProperty('y');
+      expect(floating).toHaveProperty('x', undefined);
+      expect(floating).toHaveProperty('y', undefined);
     });
   });
 

--- a/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 import { FloatingCard } from '.';
 import {
@@ -40,11 +41,20 @@ vi.mock('@accelint/design-toolkit/components/button', () => ({
   Button: ({
     children,
     onClick,
+    'aria-label': ariaLabel,
+    'aria-pressed': ariaPressed,
   }: {
     children: React.ReactNode;
     onClick?: () => void;
+    'aria-label'?: string;
+    'aria-pressed'?: boolean;
   }) => (
-    <button onClick={onClick} type='button'>
+    <button
+      onClick={onClick}
+      type='button'
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+    >
       {children}
     </button>
   ),
@@ -52,6 +62,10 @@ vi.mock('@accelint/design-toolkit/components/button', () => ({
 
 vi.mock('@accelint/icons/cancel', () => ({
   default: () => <svg data-testid='close-icon' />,
+}));
+
+vi.mock('@accelint/icons/pin', () => ({
+  default: () => <svg data-testid='pin-icon' />,
 }));
 
 // --- Dockview mock setup ---
@@ -91,9 +105,9 @@ function triggerReady(api: MockDockviewApi) {
  */
 function ContextReader({
   onContext,
-}: {
+}: Readonly<{
   onContext: (ctx: FloatingCardContextValue) => void;
-}) {
+}>) {
   const ctx = useFloatingCard();
   onContext(ctx);
   return <div data-testid='context-reader' />;
@@ -122,6 +136,7 @@ describe('FloatingCardContext defaults', () => {
           closeCard: () => undefined,
           togglePinCard: () => undefined,
           isPinned: () => false,
+          subscribeToPinState: () => () => null,
           api: null,
         }}
       >
@@ -434,6 +449,7 @@ describe('FloatingCardContainer', () => {
           closeCard: vi.fn(),
           togglePinCard: vi.fn(),
           isPinned: () => false,
+          subscribeToPinState: () => () => null,
           api: null,
         }}
       >
@@ -531,6 +547,7 @@ describe('header adapters', () => {
           closeCard: () => undefined,
           togglePinCard: () => undefined,
           isPinned: () => false,
+          subscribeToPinState: () => () => undefined,
           api: null,
         }}
       >
@@ -606,6 +623,7 @@ describe('FloatingCard', () => {
       closeCard: vi.fn(),
       togglePinCard: vi.fn(),
       isPinned: () => false,
+      subscribeToPinState: () => () => undefined,
       api,
     };
   }
@@ -945,67 +963,86 @@ describe('multiple FloatingCardProvider instances', () => {
 });
 
 describe('pin functionality', () => {
-  it('should expose togglePinCard and isPinned via context', () => {
-    const { spy, latest } = captureContext();
-
+  it('should render a pin button in the header when "pin" is in headerActions', () => {
     render(
-      <FloatingCardProvider>
-        <ContextReader onContext={spy} />
+      <FloatingCardProvider headerActions={['pin']}>
+        <div />
       </FloatingCardProvider>,
     );
 
-    expect(typeof latest().togglePinCard).toBe('function');
-    expect(typeof latest().isPinned).toBe('function');
+    const RightAdapter =
+      capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
+
+    render(
+      <RightAdapter
+        {...makeMockAdapterProps(makeMockActivePanel('panel-1'))}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /pin/i })).toBeInTheDocument();
   });
 
-  it('should toggle a card between pinned and unpinned', () => {
-    const { spy, latest } = captureContext();
+  it('should toggle pin active state when pin button is clicked', async () => {
+    const user = userEvent.setup();
 
     render(
-      <FloatingCardProvider>
-        <ContextReader onContext={spy} />
+      <FloatingCardProvider headerActions={['pin']}>
+        <div />
       </FloatingCardProvider>,
     );
 
-    expect(latest().isPinned('card-pin' as UniqueId)).toBe(false);
+    const RightAdapter =
+      capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
 
-    act(() => {
-      latest().togglePinCard('card-pin' as UniqueId);
-    });
+    render(
+      <RightAdapter
+        {...makeMockAdapterProps(makeMockActivePanel('panel-1'))}
+      />,
+    );
 
-    expect(latest().isPinned('card-pin' as UniqueId)).toBe(true);
+    const pinButton = screen.getByRole('button', { name: /pin/i });
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false');
 
-    act(() => {
-      latest().togglePinCard('card-pin' as UniqueId);
-    });
+    await user.click(pinButton);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true');
 
-    expect(latest().isPinned('card-pin' as UniqueId)).toBe(false);
+    await user.click(pinButton);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('should clear pinned state when a card is removed via removeRef', () => {
+  it('should release pin when card is removed via removeRef', async () => {
+    const user = userEvent.setup();
     const { spy, latest } = captureContext();
 
     render(
-      <FloatingCardProvider>
+      <FloatingCardProvider headerActions={['pin']}>
         <ContextReader onContext={spy} />
       </FloatingCardProvider>,
     );
 
-    act(() => {
-      latest().togglePinCard('card-remove' as UniqueId);
-    });
+    const RightAdapter =
+      capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
 
-    expect(latest().isPinned('card-remove' as UniqueId)).toBe(true);
+    render(
+      <RightAdapter
+        {...makeMockAdapterProps(makeMockActivePanel('card-remove'))}
+      />,
+    );
+
+    const pinButton = screen.getByRole('button', { name: /pin/i });
+
+    await user.click(pinButton);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true');
 
     act(() => {
       latest().removeRef('card-remove' as UniqueId);
     });
 
-    expect(latest().isPinned('card-remove' as UniqueId)).toBe(false);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('should clear pinned state when a panel is removed via dockview', () => {
-    const { spy, latest } = captureContext();
+  it('should release pin when card is removed via dockview', async () => {
+    const user = userEvent.setup();
     const mockApi = createMockApi();
     let removePanelCallback: OnDidRemovePanelCallback | undefined;
 
@@ -1017,8 +1054,8 @@ describe('pin functionality', () => {
     );
 
     const { rerender } = render(
-      <FloatingCardProvider>
-        <ContextReader onContext={spy} />
+      <FloatingCardProvider headerActions={['pin']}>
+        <div />
       </FloatingCardProvider>,
     );
 
@@ -1027,21 +1064,29 @@ describe('pin functionality', () => {
     });
 
     rerender(
-      <FloatingCardProvider>
-        <ContextReader onContext={spy} />
+      <FloatingCardProvider headerActions={['pin']}>
+        <div />
       </FloatingCardProvider>,
     );
 
-    act(() => {
-      latest().togglePinCard('pinned-removed' as UniqueId);
-    });
+    const RightAdapter =
+      capturedProps.rightHeaderActionsComponent as FunctionComponent<IDockviewHeaderActionsProps>;
 
-    expect(latest().isPinned('pinned-removed' as UniqueId)).toBe(true);
+    render(
+      <RightAdapter
+        {...makeMockAdapterProps(makeMockActivePanel('pinned-removed'))}
+      />,
+    );
+
+    const pinButton = screen.getByRole('button', { name: /pin/i });
+
+    await user.click(pinButton);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'true');
 
     act(() => {
       removePanelCallback?.({ id: 'pinned-removed' });
     });
 
-    expect(latest().isPinned('pinned-removed' as UniqueId)).toBe(false);
+    expect(pinButton).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/packages/design-toolkit/src/components/floating-card/index.tsx
+++ b/packages/design-toolkit/src/components/floating-card/index.tsx
@@ -50,6 +50,12 @@ export type FloatingCardProps = Readonly<{
    * @defaultValue { width: 300, height: 400 }
    */
   initialDimensions?: Readonly<{ width: number; height: number }>;
+  /**
+   * Initial position of the floating card panel.
+   *
+   * When provided, sets the x and y coordinates of the floating card.
+   */
+  initialPosition?: Readonly<{ x: number; y: number }>;
 }>;
 
 /**
@@ -62,6 +68,7 @@ export type FloatingCardProps = Readonly<{
  * @param title - Optional title displayed in the floating card header.
  * @param isOpen - Whether the floating card is rendered. Defaults to `true`.
  * @param initialDimensions - Initial width and height of the floating card. Defaults to `{ width: 300, height: 400 }`.
+ * @param initialPosition - Initial x and y coordinates of the floating card.
  * @param children - React children to render inside the floating card.
  * @returns The floating card component (portaled content) or null.
  *
@@ -98,6 +105,7 @@ export function FloatingCard({
   title,
   isOpen = true,
   initialDimensions,
+  initialPosition,
 }: PropsWithChildren<FloatingCardProps>) {
   const floatingCardContext = useFloatingCard();
 
@@ -119,14 +127,22 @@ export function FloatingCard({
         id,
         title,
         component: 'default',
-        floating: { width, height },
+        floating: { width, height, ...initialPosition },
       });
 
       panel.group.locked = 'no-drop-target';
     }
 
     // Cleanup not included here. Cleanup is done at the provider level when the card is removed from the `cards` registry.
-  }, [id, title, isOpen, width, height, floatingCardContext.api]);
+  }, [
+    id,
+    title,
+    isOpen,
+    width,
+    height,
+    initialPosition,
+    floatingCardContext.api,
+  ]);
 
   useEffect(() => {
     const panel = floatingCardContext.api?.getPanel(id);

--- a/packages/design-toolkit/src/components/floating-card/index.tsx
+++ b/packages/design-toolkit/src/components/floating-card/index.tsx
@@ -107,51 +107,42 @@ export function FloatingCard({
   initialDimensions,
   initialPosition,
 }: PropsWithChildren<FloatingCardProps>) {
-  const floatingCardContext = useFloatingCard();
+  const { cards, api: floatingCardApi } = useFloatingCard();
 
   const { width, height } = initialDimensions ?? defaultDimensions;
+  const { x, y } = initialPosition ?? {};
 
   // Register card with Dockview API when isOpen changes.
   // Early return if API not ready (Dockview not fully initialized).
   useEffect(() => {
-    if (!floatingCardContext.api) {
+    if (!floatingCardApi) {
       return;
     }
     if (!isOpen) {
-      floatingCardContext.api.getPanel(id)?.api.close();
+      floatingCardApi.getPanel(id)?.api.close();
       return;
     }
 
-    if (!floatingCardContext.api.getPanel(id)) {
-      const panel = floatingCardContext.api.addPanel({
+    if (!floatingCardApi.getPanel(id)) {
+      const panel = floatingCardApi.addPanel({
         id,
         title,
         component: 'default',
-        floating: { width, height, ...initialPosition },
+        floating: { width, height, x, y },
       });
 
       panel.group.locked = 'no-drop-target';
     }
 
     // Cleanup not included here. Cleanup is done at the provider level when the card is removed from the `cards` registry.
-  }, [
-    id,
-    title,
-    isOpen,
-    width,
-    height,
-    initialPosition,
-    floatingCardContext.api,
-  ]);
+  }, [id, title, isOpen, width, height, x, y, floatingCardApi]);
 
   useEffect(() => {
-    const panel = floatingCardContext.api?.getPanel(id);
+    const panel = floatingCardApi?.getPanel(id);
     if (panel) {
       panel.setTitle(title ?? id);
     }
-  }, [title, floatingCardContext.api, id]);
+  }, [title, floatingCardApi, id]);
 
-  return isOpen && floatingCardContext.cards[id]
-    ? createPortal(children, floatingCardContext.cards[id])
-    : null;
+  return isOpen && cards[id] ? createPortal(children, cards[id]) : null;
 }

--- a/packages/design-toolkit/src/components/floating-card/index.tsx
+++ b/packages/design-toolkit/src/components/floating-card/index.tsx
@@ -17,8 +17,23 @@ import type { UniqueId } from '@accelint/core';
 
 const defaultDimensions = { width: 300, height: 400 } as const;
 
+/**
+ * Props for the FloatingCard component.
+ *
+ * @example
+ * ```tsx
+ * const props: FloatingCardProps = {
+ *   id: 'panel-123' as UniqueId,
+ *   title: 'My Panel',
+ *   isOpen: true,
+ *   initialDimensions: { width: 350, height: 450 }
+ * };
+ * ```
+ */
 export type FloatingCardProps = Readonly<{
+  /** Unique identifier for the floating card */
   id: UniqueId;
+  /** Optional title displayed in the floating card header */
   title?: string;
   /**
    * Controls whether the floating card is rendered.
@@ -48,10 +63,34 @@ export type FloatingCardProps = Readonly<{
  * @param isOpen - Whether the floating card is rendered. Defaults to `true`.
  * @param initialDimensions - Initial width and height of the floating card. Defaults to `{ width: 300, height: 400 }`.
  * @param children - React children to render inside the floating card.
+ * @returns The floating card component (portaled content) or null.
  *
  * @remarks
  * - Requires `FloatingCardProvider` as an ancestor.
  * - The floating card is only rendered if a valid DOM reference exists for the given `id`.
+ *
+ * @example
+ * ```tsx
+ * import { uuid } from '@accelint/core/utility/uuid';
+ *
+ * const cardId = uuid();
+ * const [isOpen, setIsOpen] = useState(true);
+ *
+ * <FloatingCardProvider>
+ *   <FloatingCard
+ *     id={cardId}
+ *     title="Settings Panel"
+ *     isOpen={isOpen}
+ *     initialDimensions={{ width: 400, height: 500 }}
+ *   >
+ *     <SettingsForm />
+ *   </FloatingCard>
+ *
+ *   <button onClick={() => setIsOpen(!isOpen)}>
+ *     Toggle Panel
+ *   </button>
+ * </FloatingCardProvider>
+ * ```
  */
 export function FloatingCard({
   id,
@@ -64,8 +103,9 @@ export function FloatingCard({
 
   const { width, height } = initialDimensions ?? defaultDimensions;
 
+  // Register card with Dockview API when isOpen changes.
+  // Early return if API not ready (Dockview not fully initialized).
   useEffect(() => {
-    // If the API is not available, we cannot register the card. This can happen if Dockview is not fully initialized yet.
     if (!floatingCardContext.api) {
       return;
     }

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -12,6 +12,7 @@
 
 import { clsx } from '@accelint/design-foundation/lib/utils';
 import CloseIcon from '@accelint/icons/cancel';
+import PinIcon from '@accelint/icons/pin';
 import {
   type DockviewApi,
   DockviewReact,
@@ -26,6 +27,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { Button } from '../button';
@@ -39,42 +41,113 @@ import {
 import styles from './styles.module.css';
 import type { UniqueId } from '@accelint/core/utility/uuid';
 
-/** A value that is either `T` directly, or a function that receives the active card id and returns `T`. */
+/**
+ * A value that can be static or dynamically computed per floating card.
+ *
+ * Enables per-card customization of props by passing a factory function
+ * that receives the card ID and returns the appropriate value.
+ *
+ * @template T - The type of the static value or factory return type.
+ */
 type MaybeFactory<T> = T | ((cardId: string) => T);
 
+/**
+ * Configuration for header action buttons in floating cards.
+ *
+ * Can be a custom button (with icon and onClick), a visual separator ('divider'),
+ * or the built-in pin toggle ('pin').
+ *
+ * @remarks
+ * - Custom buttons: Rendered as icon buttons with your provided onClick handler
+ * - 'divider': Inserts a vertical divider between action groups
+ * - 'pin': Adds built-in pin toggle button (disables dragging when pinned)
+ *
+ * @example
+ * ```tsx
+ * const headerActions: FloatingCardHeaderAction[] = [
+ *   { icon: <SettingsIcon />, onClick: () => openSettings() },
+ *   'divider',
+ *   'pin'
+ * ];
+ * ```
+ */
+export type FloatingCardHeaderAction =
+  | {
+      /** Icon to display in the action button */
+      icon: ReactNode;
+      /** Handler called when the action button is clicked */
+      onClick: () => void;
+    }
+  | 'divider'
+  | 'pin';
+
+/**
+ * Props passed to floating card header components.
+ *
+ * @remarks Internal type used by header adapters to map Dockview props to custom header components.
+ */
 type FloatingCardHeaderProps = {
+  /** ID of the active floating card panel */
   id?: string;
+  /** Title text displayed in the header */
   title?: string;
+  /** Optional icon displayed at the start of the header */
   icon?: ReactNode;
+  /** Callback to close the entire card group */
   closeGroup: () => void;
-  headerActions?: (
-    | {
-        icon: ReactNode;
-        onClick: () => void;
-      }
-    | 'divider'
-  )[];
+  /** Toggles pin state for the specified card */
+  togglePinCard: (id: UniqueId) => void;
+  /** Checks if the specified card is pinned */
+  isPinned: (id: UniqueId) => boolean;
+  /** Custom action buttons to render in the header */
+  headerActions?: FloatingCardHeaderAction[];
 };
 
 /**
  * Internal component that registers a DOM ref for a card container.
- * Used by the floating card engine to mount portal targets.
+ *
+ * Used by the floating card engine to mount portal targets. Also manages
+ * the data-pinned attribute on the resize container to control drag handle visibility.
+ *
+ * @param props - Dockview panel props containing the card ID.
  */
 function FloatingCardContainer(props: Readonly<IDockviewPanelProps>) {
-  const { addRef } = useFloatingCard();
+  const { addRef, isPinned } = useFloatingCard();
+  const cardId = props.api.id as UniqueId;
+  const pinned = isPinned(cardId);
+
+  const cardRef = useRef<HTMLDivElement | null>(null);
 
   const refCallback = useCallback(
     (ref: HTMLDivElement | null) => {
-      addRef(props.api.id as UniqueId, ref);
+      cardRef.current = ref;
+      addRef(cardId, ref);
     },
-    [addRef, props.api.id],
+    [addRef, cardId],
   );
+
+  // Toggle a data-pinned attribute on the ancestor .dv-resize-container
+  // so CSS can disable pointer-events on the drag handle.
+  useEffect(() => {
+    const el = cardRef.current;
+    const container = el?.closest('.dv-resize-container') as HTMLElement | null;
+
+    if (!container) {
+      return;
+    }
+
+    if (pinned) {
+      container.dataset.pinned = '';
+    } else {
+      delete container.dataset.pinned;
+    }
+  }, [pinned]);
 
   return <div className={styles.cardContent} ref={refCallback} />;
 }
 
 /**
- * Default left header showing an optional custom icon (or a placeholder) and the card's title.
+ * Default left header showing an optional custom icon and the card's title.
  */
 function DefaultLeftHeader({
   title,
@@ -93,12 +166,18 @@ function DefaultLeftHeader({
 
 /**
  * Default right header showing optional action buttons and an always-present close button.
+ *
+ * @remarks Handles rendering of 'divider' and 'pin' action types specially.
  */
 function DefaultRightHeader({
   closeGroup,
   headerActions,
   id,
+  togglePinCard,
+  isPinned,
 }: Readonly<FloatingCardHeaderProps>) {
+  const pinned = id ? isPinned(id as UniqueId) : false;
+
   return (
     <div className={styles.headerSide}>
       {headerActions?.map((action, index) => {
@@ -106,6 +185,27 @@ function DefaultRightHeader({
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: Using index as key is acceptable here because the order of actions is unlikely to change.
             <Divider key={`${id}-divider-${index}`} orientation='vertical' />
+          );
+        }
+        if (action === 'pin') {
+          return (
+            <Button
+              className={styles.pinButton}
+              // biome-ignore lint/suspicious/noArrayIndexKey: Using index as key is acceptable here because the order of actions is unlikely to change.
+              key={`${id}-pin-${index}`}
+              variant='icon'
+              size='small'
+              color={pinned ? 'accent' : undefined}
+              onClick={() => {
+                if (id) {
+                  togglePinCard(id as UniqueId);
+                }
+              }}
+            >
+              <Icon>
+                <PinIcon />
+              </Icon>
+            </Button>
           );
         }
         return (
@@ -134,14 +234,23 @@ function DefaultRightHeader({
 type HeaderAdapterOptions = {
   icon?: MaybeFactory<ReactNode>;
   headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
+  togglePinCard: (id: UniqueId) => void;
+  isPinned: (id: UniqueId) => boolean;
 };
 
 /**
- * Creates an adapter component to map Dockview's header action props to our custom header component props.
+ * Creates an adapter component to map Dockview's header action props to custom header component props.
+ *
+ * Handles title change subscriptions and resolves MaybeFactory options (icon, headerActions)
+ * either as static values or by invoking factory functions with the active card ID.
+ *
+ * @param Component - The header component to wrap.
+ * @param options - Configuration options including icon and headerActions (static or factory).
+ * @returns Adapter component compatible with Dockview's header API.
  */
 function createHeaderAdapter(
   Component: FunctionComponent<FloatingCardHeaderProps>,
-  options?: HeaderAdapterOptions,
+  options: HeaderAdapterOptions,
 ): FunctionComponent<IDockviewHeaderActionsProps> {
   function HeaderAdapter(props: Readonly<IDockviewHeaderActionsProps>) {
     const panelId = props.panels[0]?.id ?? '';
@@ -180,6 +289,8 @@ function createHeaderAdapter(
         title={title}
         id={props.activePanel?.id}
         closeGroup={() => props.api.close()}
+        togglePinCard={options.togglePinCard}
+        isPinned={options.isPinned}
       />
     );
   }
@@ -188,6 +299,27 @@ function createHeaderAdapter(
   return HeaderAdapter;
 }
 
+/**
+ * Props for the FloatingCardProvider component.
+ *
+ * Configures default icon and header actions for all floating cards. Both can be
+ * static values or factory functions that receive the card ID for per-card customization.
+ *
+ * @example
+ * ```tsx
+ * <FloatingCardProvider
+ *   icon={<AppIcon />}
+ *   headerActions={(cardId) => {
+ *     if (cardId === 'settings') {
+ *       return [{ icon: <CogIcon />, onClick: openSettings }, 'pin'];
+ *     }
+ *     return ['pin'];
+ *   }}
+ * >
+ *   {children}
+ * </FloatingCardProvider>
+ * ```
+ */
 export type FloatingCardProviderProps = Readonly<
   PropsWithChildren<{
     /**
@@ -197,19 +329,12 @@ export type FloatingCardProviderProps = Readonly<
     icon?: MaybeFactory<ReactNode>;
     /**
      * Optional action buttons rendered in the floating card header before the close button.
-     * Can include dividers to separate groups of actions.
+     * Can include `'divider'` to separate groups and `'pin'` to add a pin toggle button.
      * Can be an array or a function `(cardId: string) => array` to return
      * per-floating card actions.
      */
-    headerActions?: MaybeFactory<
-      (
-        | {
-            icon: ReactNode;
-            onClick: () => void;
-          }
-        | 'divider'
-      )[]
-    >;
+    headerActions?: MaybeFactory<FloatingCardHeaderAction[]>;
+    /** Additional CSS class names for styling */
     className?: string;
   }>
 >;
@@ -221,21 +346,37 @@ const components: Record<string, FunctionComponent<IDockviewPanelProps>> = {
 /**
  * Provides a context and layout area for floating cards within the application.
  *
- * Wraps its children with floating card context and renders a floating card engine instance
- * to manage docking and layout.
+ * Wraps children with floating card context and renders a Dockview instance to manage
+ * docking, dragging, and layout of floating cards.
  *
  * @param props - The props for the FloatingCardProvider component.
  * @param props.children - Child components rendered inside the floating card provider.
- * @param props.icon - Optional icon.
- * @param props.headerActions - Optional actions for the header.
+ * @param props.icon - Optional icon rendered in all card headers (static or factory).
+ * @param props.headerActions - Optional action buttons for card headers (static or factory).
  * @param props.className - Additional CSS class names for styling.
- *
  * @returns The FloatingCardProvider component that manages floating card layout and context.
  *
  * @remarks
- * - Manages registration and unregistration of floating card references.
- * - Exposes `closeCard` via context for child components.
- * - Ensures floating cards are bounded within the viewport.
+ * - Manages registration and cleanup of floating card DOM references
+ * - Exposes closeCard, togglePinCard, and isPinned via context
+ * - Automatically cleans up refs when cards are removed via any path (drag close, group close, API close)
+ * - Cards are bounded within the viewport
+ *
+ * @example
+ * ```tsx
+ * <FloatingCardProvider
+ *   icon={<AppLogo />}
+ *   headerActions={[
+ *     { icon: <SettingsIcon />, onClick: openSettings },
+ *     'divider',
+ *     'pin'
+ *   ]}
+ * >
+ *   <FloatingCard id="panel-1" title="My Panel">
+ *     <div>Panel content</div>
+ *   </FloatingCard>
+ * </FloatingCardProvider>
+ * ```
  */
 export function FloatingCardProvider({
   children,
@@ -245,6 +386,7 @@ export function FloatingCardProvider({
 }: FloatingCardProviderProps) {
   const [api, setApi] = useState<DockviewApi | null>(null);
   const [cards, setCards] = useState<Record<UniqueId, HTMLDivElement>>({});
+  const [pinnedCards, setPinnedCards] = useState<Set<UniqueId>>(new Set());
 
   const closeCard = useCallback(
     (id: UniqueId) => {
@@ -253,11 +395,36 @@ export function FloatingCardProvider({
     [api],
   );
 
+  const togglePinCard = useCallback((id: UniqueId) => {
+    setPinnedCards((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const isPinned = useCallback(
+    (id: UniqueId) => pinnedCards.has(id),
+    [pinnedCards],
+  );
+
   const removeRef = useCallback((view: UniqueId) => {
     setCards((prev) => {
       const newCards = { ...prev };
       delete newCards[view];
       return newCards;
+    });
+    setPinnedCards((prev) => {
+      if (!prev.has(view)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(view);
+      return next;
     });
   }, []);
 
@@ -294,19 +461,31 @@ export function FloatingCardProvider({
       addRef,
       removeRef,
       closeCard,
+      togglePinCard,
+      isPinned,
       api,
     }),
-    [cards, closeCard, removeRef, api, addRef],
+    [cards, closeCard, removeRef, api, addRef, togglePinCard, isPinned],
   );
 
   const leftAdapter = useMemo(
-    () => createHeaderAdapter(DefaultLeftHeader, { icon }),
-    [icon],
+    () =>
+      createHeaderAdapter(DefaultLeftHeader, {
+        icon,
+        togglePinCard,
+        isPinned,
+      }),
+    [icon, togglePinCard, isPinned],
   );
 
   const rightAdapter = useMemo(
-    () => createHeaderAdapter(DefaultRightHeader, { headerActions }),
-    [headerActions],
+    () =>
+      createHeaderAdapter(DefaultRightHeader, {
+        headerActions,
+        togglePinCard,
+        isPinned,
+      }),
+    [headerActions, togglePinCard, isPinned],
   );
 
   const theme = useMemo(

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -354,6 +354,13 @@ export type FloatingCardProviderProps = Readonly<
      * per-floating card actions.
      */
     headerActions?: MaybeFactory<FloatingCardHeaderAction[]>;
+    /**
+     * Optional set of card IDs that should be pinned when the provider first mounts.
+     *
+     * Like other `initial*` props, this value is only read once at mount time.
+     * Changes after mount have no effect.
+     */
+    initialPinned?: readonly UniqueId[];
     /** Additional CSS class names for styling */
     className?: string;
   }>
@@ -402,11 +409,12 @@ export function FloatingCardProvider({
   children,
   icon,
   headerActions,
+  initialPinned,
   className,
 }: FloatingCardProviderProps) {
   const [api, setApi] = useState<DockviewApi | null>(null);
   const [cards, setCards] = useState<Record<UniqueId, HTMLDivElement>>({});
-  const pinnedCardsRef = useRef<Set<UniqueId>>(new Set());
+  const pinnedCardsRef = useRef<Set<UniqueId>>(new Set(initialPinned));
   const pinListenersRef = useRef<Set<() => void>>(new Set());
 
   const closeCard = useCallback(

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -130,7 +130,7 @@ function FloatingCardContainer(props: Readonly<IDockviewPanelProps>) {
   // so CSS can disable pointer-events on the drag handle.
   useEffect(() => {
     const el = cardRef.current;
-    const container = el?.closest('.dv-resize-container') as HTMLElement | null;
+    const container = el?.closest<HTMLElement>('.dv-resize-container');
 
     if (!container) {
       return;

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -29,6 +29,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import { Button } from '../button';
 import { Divider } from '../divider';
@@ -96,9 +97,11 @@ type FloatingCardHeaderProps = {
   /** Callback to close the entire card group */
   closeGroup: () => void;
   /** Toggles pin state for the specified card */
-  togglePinCard: (id: UniqueId) => void;
+  togglePinCard?: (id: UniqueId) => void;
   /** Checks if the specified card is pinned */
-  isPinned: (id: UniqueId) => boolean;
+  isPinned?: (id: UniqueId) => boolean;
+  /** Subscribes to pin state changes; returns an unsubscribe function */
+  subscribeToPinState?: (callback: () => void) => () => void;
   /** Custom action buttons to render in the header */
   headerActions?: FloatingCardHeaderAction[];
 };
@@ -112,9 +115,14 @@ type FloatingCardHeaderProps = {
  * @param props - Dockview panel props containing the card ID.
  */
 function FloatingCardContainer(props: Readonly<IDockviewPanelProps>) {
-  const { addRef, isPinned } = useFloatingCard();
+  const { addRef, isPinned, subscribeToPinState } = useFloatingCard();
   const cardId = props.api.id as UniqueId;
-  const pinned = isPinned(cardId);
+
+  const pinned = useSyncExternalStore(
+    subscribeToPinState,
+    () => isPinned(cardId),
+    () => false,
+  );
 
   const cardRef = useRef<HTMLDivElement | null>(null);
 
@@ -164,6 +172,9 @@ function DefaultLeftHeader({
   );
 }
 
+/** Stable no-op subscribe for useSyncExternalStore when no pin subscription is available. */
+const noopSubscribe = () => () => undefined;
+
 /**
  * Default right header showing optional action buttons and an always-present close button.
  *
@@ -175,8 +186,13 @@ function DefaultRightHeader({
   id,
   togglePinCard,
   isPinned,
+  subscribeToPinState,
 }: Readonly<FloatingCardHeaderProps>) {
-  const pinned = id ? isPinned(id as UniqueId) : false;
+  const pinned = useSyncExternalStore(
+    subscribeToPinState ?? noopSubscribe,
+    () => (id && isPinned ? isPinned(id as UniqueId) : false),
+    () => false,
+  );
 
   return (
     <div className={styles.headerSide}>
@@ -196,8 +212,10 @@ function DefaultRightHeader({
               variant='icon'
               size='small'
               color={pinned ? 'accent' : undefined}
+              aria-label='Pin'
+              aria-pressed={pinned}
               onClick={() => {
-                if (id) {
+                if (id && togglePinCard) {
                   togglePinCard(id as UniqueId);
                 }
               }}
@@ -234,8 +252,9 @@ function DefaultRightHeader({
 type HeaderAdapterOptions = {
   icon?: MaybeFactory<ReactNode>;
   headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
-  togglePinCard: (id: UniqueId) => void;
-  isPinned: (id: UniqueId) => boolean;
+  togglePinCard?: (id: UniqueId) => void;
+  isPinned?: (id: UniqueId) => boolean;
+  subscribeToPinState?: (callback: () => void) => () => void;
 };
 
 /**
@@ -291,6 +310,7 @@ function createHeaderAdapter(
         closeGroup={() => props.api.close()}
         togglePinCard={options.togglePinCard}
         isPinned={options.isPinned}
+        subscribeToPinState={options.subscribeToPinState}
       />
     );
   }
@@ -386,7 +406,8 @@ export function FloatingCardProvider({
 }: FloatingCardProviderProps) {
   const [api, setApi] = useState<DockviewApi | null>(null);
   const [cards, setCards] = useState<Record<UniqueId, HTMLDivElement>>({});
-  const [pinnedCards, setPinnedCards] = useState<Set<UniqueId>>(new Set());
+  const pinnedCardsRef = useRef<Set<UniqueId>>(new Set());
+  const pinListenersRef = useRef<Set<() => void>>(new Set());
 
   const closeCard = useCallback(
     (id: UniqueId) => {
@@ -396,21 +417,29 @@ export function FloatingCardProvider({
   );
 
   const togglePinCard = useCallback((id: UniqueId) => {
-    setPinnedCards((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+    const next = new Set(pinnedCardsRef.current);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    pinnedCardsRef.current = next;
+    for (const listener of pinListenersRef.current) {
+      listener();
+    }
   }, []);
 
   const isPinned = useCallback(
-    (id: UniqueId) => pinnedCards.has(id),
-    [pinnedCards],
+    (id: UniqueId) => pinnedCardsRef.current.has(id),
+    [],
   );
+
+  const subscribeToPinState = useCallback((callback: () => void) => {
+    pinListenersRef.current.add(callback);
+    return () => {
+      pinListenersRef.current.delete(callback);
+    };
+  }, []);
 
   const removeRef = useCallback((view: UniqueId) => {
     setCards((prev) => {
@@ -418,14 +447,14 @@ export function FloatingCardProvider({
       delete newCards[view];
       return newCards;
     });
-    setPinnedCards((prev) => {
-      if (!prev.has(view)) {
-        return prev;
-      }
-      const next = new Set(prev);
+    if (pinnedCardsRef.current.has(view)) {
+      const next = new Set(pinnedCardsRef.current);
       next.delete(view);
-      return next;
-    });
+      pinnedCardsRef.current = next;
+      for (const listener of pinListenersRef.current) {
+        listener();
+      }
+    }
   }, []);
 
   const addRef = useCallback((id: UniqueId, ref: HTMLDivElement | null) => {
@@ -463,19 +492,27 @@ export function FloatingCardProvider({
       closeCard,
       togglePinCard,
       isPinned,
+      subscribeToPinState,
       api,
     }),
-    [cards, closeCard, removeRef, api, addRef, togglePinCard, isPinned],
+    [
+      cards,
+      closeCard,
+      removeRef,
+      api,
+      addRef,
+      togglePinCard,
+      isPinned,
+      subscribeToPinState,
+    ],
   );
 
   const leftAdapter = useMemo(
     () =>
       createHeaderAdapter(DefaultLeftHeader, {
         icon,
-        togglePinCard,
-        isPinned,
       }),
-    [icon, togglePinCard, isPinned],
+    [icon],
   );
 
   const rightAdapter = useMemo(
@@ -484,8 +521,9 @@ export function FloatingCardProvider({
         headerActions,
         togglePinCard,
         isPinned,
+        subscribeToPinState,
       }),
-    [headerActions, togglePinCard, isPinned],
+    [headerActions, togglePinCard, isPinned, subscribeToPinState],
   );
 
   const theme = useMemo(

--- a/packages/design-toolkit/src/components/floating-card/styles.module.css
+++ b/packages/design-toolkit/src/components/floating-card/styles.module.css
@@ -56,5 +56,10 @@
     :global(.dv-void-container) {
       cursor: grab;
     }
+
+    :global(.dv-resize-container[data-pinned]) :global(.dv-void-container) {
+      pointer-events: none;
+      cursor: default;
+    }
   }
 }

--- a/packages/design-toolkit/src/index.ts
+++ b/packages/design-toolkit/src/index.ts
@@ -266,7 +266,10 @@ export type {
 export { FloatingCard } from './components/floating-card';
 export type { FloatingCardProps } from './components/floating-card';
 export { FloatingCardProvider } from './components/floating-card/provider';
-export type { FloatingCardProviderProps } from './components/floating-card/provider';
+export type {
+  FloatingCardHeaderAction,
+  FloatingCardProviderProps,
+} from './components/floating-card/provider';
 export { GanttContentContainer } from './components/gantt/components/containers/external/gantt-content-container';
 export { GanttPanelContainer } from './components/gantt/components/containers/external/gantt-panel-container';
 export { GanttBlock } from './components/gantt/components/content-row/block';


### PR DESCRIPTION
Added floating card pinning feature. Cards can be pinned to disable dragging via a `'pin'` header action. Includes `togglePinCard` and `isPinned` on the floating card context, and a new `FloatingCardHeaderAction` type supporting `'pin'` alongside existing `'divider'` and custom button actions.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [x] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

1. Pin button renders in the header
Steps:

Open the Pinnable story.
Expected: A pin icon button appears in the card header, to the left of the close button.

2. Clicking the pin button activates pinned state (visual)
Steps:

Confirm the pin button is in its default (unpinned) state — no accent color.
Click the pin button.
Expected: The pin button changes to accent color, indicating the card is pinned.

3. Dragging is disabled when pinned
Steps:

Click the pin button to pin the card.
Attempt to drag the card by clicking and dragging the header area.
Expected: The card does not move. The cursor does not show a grab cursor over the drag handle.

4. Unpinning re-enables dragging
Steps:

With the card pinned, click the pin button again.
Attempt to drag the card by its header.
Expected: The pin button returns to its default style. The card can be dragged freely again.

5. Pin combined with other header actions
Setup: Open the WithHeaderActionDividers story (or any story with [headerActions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) containing both custom buttons and 'pin').

Steps:

Verify all action buttons render: custom icon buttons, dividers, and the pin button.
Click a custom action button — confirm its callback fires (e.g. alert).
Click the pin button — confirm it toggles independently.
Expected: Custom actions and pin action work independently without interfering with each other.

6. Pin state clears on card close
Steps:

Open the Pinnable story.
Click the pin button to pin the card.
Click the close (×) button to close the card.
Re-open the card (e.g. via [ControlledVisibility](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) story toggle, or refresh the story).
Expected: The card reopens in the unpinned state (no accent on pin button, dragging is enabled).

7. Multiple cards — pin state is per-card
Setup: Open the MultipleCards story, then modify [headerActions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include 'pin' (if a combined story is available). Otherwise, test using the app or a custom story with multiple pinnable cards.

Steps:

Pin Card A.
Attempt to drag Card A — it should not move.
Attempt to drag Card B — it should move freely.
Pin Card B.
Unpin Card A.
Verify Card A is now draggable and Card B is not.
Expected: Each card's pin state is tracked independently.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [x] Documentation
- [x] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
