### PR TITLE
fix: draggable floating card title

### DIFF
--- a/.changeset/silver-geese-cry.md
+++ b/.changeset/silver-geese-cry.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+adjusted floating card header styling so that the title does not interfere with the drag handle

--- a/packages/design-toolkit/package.json
+++ b/packages/design-toolkit/package.json
@@ -182,6 +182,8 @@
     "./components/floating-card": "./dist/components/floating-card/index.js",
     "./components/floating-card/context": "./dist/components/floating-card/context.js",
     "./components/floating-card/provider": "./dist/components/floating-card/provider.js",
+    "./components/floating-card/types": "./dist/components/floating-card/types.js",
+    "./components/floating-card/utils": "./dist/components/floating-card/utils.js",
     "./components/gantt/components/base-elements/point": "./dist/components/gantt/components/base-elements/point.js",
     "./components/gantt/components/base-elements/range": "./dist/components/gantt/components/base-elements/range.js",
     "./components/gantt/components/base-elements/use-point-element-layout": "./dist/components/gantt/components/base-elements/use-point-element-layout/index.js",

--- a/packages/design-toolkit/src/components/floating-card/context.tsx
+++ b/packages/design-toolkit/src/components/floating-card/context.tsx
@@ -12,40 +12,7 @@
  */
 
 import { createContext, useContext } from 'react';
-import type { UniqueId } from '@accelint/core/utility/uuid';
-import type { DockviewApi } from 'dockview-react';
-
-/**
- * Context value providing floating card management functionality.
- *
- * @remarks
- * Exposed via FloatingCardProvider to child components. Use useFloatingCard() hook to access.
- */
-export type FloatingCardContextValue = {
-  /** Registry mapping card IDs to their rendered DOM containers */
-  cards: Record<UniqueId, HTMLDivElement>;
-
-  /** Registers a DOM ref for a card container after it mounts */
-  addRef: (id: UniqueId, ref: HTMLDivElement | null) => void;
-
-  /** Unregisters a card's DOM ref when it's removed */
-  removeRef: (view: UniqueId) => void;
-
-  /** Programmatically closes a floating card by ID */
-  closeCard: (id: UniqueId) => void;
-
-  /** Toggles pin state for a floating card, disabling drag when pinned */
-  togglePinCard: (id: UniqueId) => void;
-
-  /** Checks if a floating card is currently pinned */
-  isPinned: (id: UniqueId) => boolean;
-
-  /** Subscribes to pin state changes; returns an unsubscribe function */
-  subscribeToPinState: (callback: () => void) => () => void;
-
-  /** Dockview API instance, null until FloatingCardProvider's onReady fires */
-  api: DockviewApi | null;
-};
+import type { FloatingCardContextValue } from './types';
 
 export const FloatingCardContext =
   createContext<FloatingCardContextValue | null>(null);

--- a/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
+++ b/packages/design-toolkit/src/components/floating-card/floating-card.test.tsx
@@ -14,11 +14,7 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 import { FloatingCard } from '.';
-import {
-  FloatingCardContext,
-  type FloatingCardContextValue,
-  useFloatingCard,
-} from './context';
+import { FloatingCardContext, useFloatingCard } from './context';
 import { FloatingCardProvider } from './provider';
 import type { UniqueId } from '@accelint/core/utility/uuid';
 import type {
@@ -27,6 +23,7 @@ import type {
   IDockviewPanelProps,
 } from 'dockview-react';
 import type { FunctionComponent } from 'react';
+import type { FloatingCardContextValue } from './types';
 
 // --- Design toolkit component mocks ---
 // Icon and Button import `client-only` which is not compatible with the jsdom

--- a/packages/design-toolkit/src/components/floating-card/index.tsx
+++ b/packages/design-toolkit/src/components/floating-card/index.tsx
@@ -13,50 +13,9 @@
 import { type PropsWithChildren, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useFloatingCard } from './context';
-import type { UniqueId } from '@accelint/core';
+import type { FloatingCardProps } from './types';
 
 const defaultDimensions = { width: 300, height: 400 } as const;
-
-/**
- * Props for the FloatingCard component.
- *
- * @example
- * ```tsx
- * const props: FloatingCardProps = {
- *   id: 'panel-123' as UniqueId,
- *   title: 'My Panel',
- *   isOpen: true,
- *   initialDimensions: { width: 350, height: 450 }
- * };
- * ```
- */
-export type FloatingCardProps = Readonly<{
-  /** Unique identifier for the floating card */
-  id: UniqueId;
-  /** Optional title displayed in the floating card header */
-  title?: string;
-  /**
-   * Controls whether the floating card is rendered.
-   *
-   * When `true`, the card registers with the floating card engine and renders its
-   * children via a portal. When `false`, the card is closed and removed.
-   *
-   * @defaultValue true
-   */
-  isOpen?: boolean;
-  /**
-   * Initial dimensions of the floating card panel.
-   *
-   * @defaultValue { width: 300, height: 400 }
-   */
-  initialDimensions?: Readonly<{ width: number; height: number }>;
-  /**
-   * Initial position of the floating card panel.
-   *
-   * When provided, sets the x and y coordinates of the floating card.
-   */
-  initialPosition?: Readonly<{ x: number; y: number }>;
-}>;
 
 /**
  * Renders its children into a floating card using React portals.

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -17,7 +17,6 @@ import {
   type DockviewApi,
   DockviewReact,
   type DockviewReadyEvent,
-  type IDockviewHeaderActionsProps,
   type IDockviewPanelProps,
 } from 'dockview-react';
 import {
@@ -34,12 +33,11 @@ import { Divider } from '../divider';
 import { Icon } from '../icon';
 import { FloatingCardContext, useFloatingCard } from './context';
 import styles from './styles.module.css';
+import { createHeaderAdapter, type FloatingCardHeaderProps } from './utils';
 import type { UniqueId } from '@accelint/core/utility/uuid';
 import type {
   FloatingCardContextValue,
-  FloatingCardHeaderProps,
   FloatingCardProviderProps,
-  HeaderAdapterOptions,
 } from './types';
 
 /**
@@ -185,68 +183,6 @@ function DefaultRightHeader({
       </Button>
     </div>
   );
-}
-
-/**
- * Creates an adapter component to map Dockview's header action props to custom header component props.
- *
- * Handles title change subscriptions and resolves MaybeFactory options (icon, headerActions)
- * either as static values or by invoking factory functions with the active card ID.
- *
- * @param Component - The header component to wrap.
- * @param options - Configuration options including icon and headerActions (static or factory).
- * @returns Adapter component compatible with Dockview's header API.
- */
-function createHeaderAdapter(
-  Component: FunctionComponent<FloatingCardHeaderProps>,
-  options: HeaderAdapterOptions,
-): FunctionComponent<IDockviewHeaderActionsProps> {
-  function HeaderAdapter(props: Readonly<IDockviewHeaderActionsProps>) {
-    const panelId = props.panels[0]?.id ?? '';
-    const [title, setTitle] = useState(props.activePanel?.title);
-
-    useEffect(() => {
-      const panel = props.activePanel;
-
-      if (!panel) {
-        return;
-      }
-
-      setTitle(panel.title);
-
-      const disposable = panel.api.onDidTitleChange(() => {
-        setTitle(panel.title);
-      });
-
-      return () => {
-        disposable.dispose();
-      };
-    }, [props.activePanel]);
-    const icon = props.activePanel
-      ? typeof options?.icon === 'function'
-        ? options.icon(panelId)
-        : options?.icon
-      : undefined;
-    const headerActions =
-      typeof options?.headerActions === 'function'
-        ? options.headerActions(panelId)
-        : options?.headerActions;
-    return (
-      <Component
-        icon={icon}
-        headerActions={headerActions}
-        title={title}
-        id={props.activePanel?.id}
-        closeGroup={() => props.api.close()}
-        togglePinCard={options.togglePinCard}
-        isPinned={options.isPinned}
-        subscribeToPinState={options.subscribeToPinState}
-      />
-    );
-  }
-
-  HeaderAdapter.displayName = `HeaderAdapter(${Component.displayName ?? Component.name ?? 'Anonymous'})`;
-  return HeaderAdapter;
 }
 
 const components: Record<string, FunctionComponent<IDockviewPanelProps>> = {

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -166,7 +166,9 @@ function DefaultLeftHeader({
     <div className={styles.headerSide}>
       {icon ? <Icon size='small'>{icon}</Icon> : null}
       {title && title !== id ? (
-        <div className={styles.headerTitle}>{title}</div>
+        <div className={styles.headerTitleContainer}>
+          <div className={styles.headerTitle}>{title}</div>
+        </div>
       ) : null}
     </div>
   );

--- a/packages/design-toolkit/src/components/floating-card/provider.tsx
+++ b/packages/design-toolkit/src/components/floating-card/provider.tsx
@@ -22,8 +22,6 @@ import {
 } from 'dockview-react';
 import {
   type FunctionComponent,
-  type PropsWithChildren,
-  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -34,77 +32,15 @@ import {
 import { Button } from '../button';
 import { Divider } from '../divider';
 import { Icon } from '../icon';
-import {
-  FloatingCardContext,
-  type FloatingCardContextValue,
-  useFloatingCard,
-} from './context';
+import { FloatingCardContext, useFloatingCard } from './context';
 import styles from './styles.module.css';
 import type { UniqueId } from '@accelint/core/utility/uuid';
-
-/**
- * A value that can be static or dynamically computed per floating card.
- *
- * Enables per-card customization of props by passing a factory function
- * that receives the card ID and returns the appropriate value.
- *
- * @template T - The type of the static value or factory return type.
- */
-type MaybeFactory<T> = T | ((cardId: string) => T);
-
-/**
- * Configuration for header action buttons in floating cards.
- *
- * Can be a custom button (with icon and onClick), a visual separator ('divider'),
- * or the built-in pin toggle ('pin').
- *
- * @remarks
- * - Custom buttons: Rendered as icon buttons with your provided onClick handler
- * - 'divider': Inserts a vertical divider between action groups
- * - 'pin': Adds built-in pin toggle button (disables dragging when pinned)
- *
- * @example
- * ```tsx
- * const headerActions: FloatingCardHeaderAction[] = [
- *   { icon: <SettingsIcon />, onClick: () => openSettings() },
- *   'divider',
- *   'pin'
- * ];
- * ```
- */
-export type FloatingCardHeaderAction =
-  | {
-      /** Icon to display in the action button */
-      icon: ReactNode;
-      /** Handler called when the action button is clicked */
-      onClick: () => void;
-    }
-  | 'divider'
-  | 'pin';
-
-/**
- * Props passed to floating card header components.
- *
- * @remarks Internal type used by header adapters to map Dockview props to custom header components.
- */
-type FloatingCardHeaderProps = {
-  /** ID of the active floating card panel */
-  id?: string;
-  /** Title text displayed in the header */
-  title?: string;
-  /** Optional icon displayed at the start of the header */
-  icon?: ReactNode;
-  /** Callback to close the entire card group */
-  closeGroup: () => void;
-  /** Toggles pin state for the specified card */
-  togglePinCard?: (id: UniqueId) => void;
-  /** Checks if the specified card is pinned */
-  isPinned?: (id: UniqueId) => boolean;
-  /** Subscribes to pin state changes; returns an unsubscribe function */
-  subscribeToPinState?: (callback: () => void) => () => void;
-  /** Custom action buttons to render in the header */
-  headerActions?: FloatingCardHeaderAction[];
-};
+import type {
+  FloatingCardContextValue,
+  FloatingCardHeaderProps,
+  FloatingCardProviderProps,
+  HeaderAdapterOptions,
+} from './types';
 
 /**
  * Internal component that registers a DOM ref for a card container.
@@ -251,14 +187,6 @@ function DefaultRightHeader({
   );
 }
 
-type HeaderAdapterOptions = {
-  icon?: MaybeFactory<ReactNode>;
-  headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
-  togglePinCard?: (id: UniqueId) => void;
-  isPinned?: (id: UniqueId) => boolean;
-  subscribeToPinState?: (callback: () => void) => () => void;
-};
-
 /**
  * Creates an adapter component to map Dockview's header action props to custom header component props.
  *
@@ -320,53 +248,6 @@ function createHeaderAdapter(
   HeaderAdapter.displayName = `HeaderAdapter(${Component.displayName ?? Component.name ?? 'Anonymous'})`;
   return HeaderAdapter;
 }
-
-/**
- * Props for the FloatingCardProvider component.
- *
- * Configures default icon and header actions for all floating cards. Both can be
- * static values or factory functions that receive the card ID for per-card customization.
- *
- * @example
- * ```tsx
- * <FloatingCardProvider
- *   icon={<AppIcon />}
- *   headerActions={(cardId) => {
- *     if (cardId === 'settings') {
- *       return [{ icon: <CogIcon />, onClick: openSettings }, 'pin'];
- *     }
- *     return ['pin'];
- *   }}
- * >
- *   {children}
- * </FloatingCardProvider>
- * ```
- */
-export type FloatingCardProviderProps = Readonly<
-  PropsWithChildren<{
-    /**
-     * Optional icon rendered at the very start of the floating card header.
-     * Can be a `ReactNode` or a function `(cardId: string) => ReactNode`.
-     */
-    icon?: MaybeFactory<ReactNode>;
-    /**
-     * Optional action buttons rendered in the floating card header before the close button.
-     * Can include `'divider'` to separate groups and `'pin'` to add a pin toggle button.
-     * Can be an array or a function `(cardId: string) => array` to return
-     * per-floating card actions.
-     */
-    headerActions?: MaybeFactory<FloatingCardHeaderAction[]>;
-    /**
-     * Optional set of card IDs that should be pinned when the provider first mounts.
-     *
-     * Like other `initial*` props, this value is only read once at mount time.
-     * Changes after mount have no effect.
-     */
-    initialPinned?: readonly UniqueId[];
-    /** Additional CSS class names for styling */
-    className?: string;
-  }>
->;
 
 const components: Record<string, FunctionComponent<IDockviewPanelProps>> = {
   default: FloatingCardContainer,

--- a/packages/design-toolkit/src/components/floating-card/styles.module.css
+++ b/packages/design-toolkit/src/components/floating-card/styles.module.css
@@ -32,10 +32,14 @@
     @apply text-header-m pl-xs pointer-events-none h-full w-0;
   }
 
-  /** The header title is set to a min-width to prevent it from collapsing when the title is long, and truncating the overflow text.  */
-  /** Its width is based on the width of the floating card header via a container query, accounting for the padding and other elements in the header. */
+  /* Explicit width based on the header's container query width so long titles
+     truncate within the header rather than pushing siblings or overflowing.
+     The 10rem reserves space for the leading icon, header padding, gap, and
+     right-side action buttons; adjust when those change.
+     The @min-[1rem]/floating-card-header variant scopes the rule to cases
+     where the named container exists, so cqw never falls back to the viewport. */
   .headerTitle {
-    @apply h-full truncate align-middle leading-24 @min-[1rem]/floating-card-header:w-[calc(100cqw-10rem)];
+    @apply h-full truncate leading-24 @min-[1rem]/floating-card-header:w-[calc(100cqw-10rem)];
   }
 
   .floatingCardProvider {

--- a/packages/design-toolkit/src/components/floating-card/styles.module.css
+++ b/packages/design-toolkit/src/components/floating-card/styles.module.css
@@ -22,11 +22,18 @@
   }
 
   .headerSide {
-    @apply gap-xs flex h-full items-center;
+    @apply gap-xs relative flex h-full items-center;
   }
 
+  .headerTitleContainer {
+    /** The header title container is set to a width of 0 to maximize the width of the drag handle, which we have no control over (dv-draggable).  */
+    @apply text-header-m pl-xs pointer-events-none h-full w-0;
+  }
+
+  /** The header title is set to a min-width to prevent it from collapsing when the title is long, and truncating the overflow text.  */
+  /** Its width is based on the width of the floating card header via a container query, accounting for the padding and other elements in the header. */
   .headerTitle {
-    @apply text-header-m pl-xs;
+    @apply h-full w-[calc(100cqw-10rem)] truncate align-middle leading-24 @min-[1rem]/floating-card-header:w-[calc(100cqw-10rem)];
   }
 
   .floatingCardProvider {
@@ -48,7 +55,7 @@
 
     :global(.dv-tabs-and-actions-container) {
       --dv-tabs-and-actions-container-height: 32px;
-      @apply p-xs text-header-m;
+      @apply p-xs text-header-m @container/floating-card-header;
     }
     :global(.dv-scrollable) {
       display: none;

--- a/packages/design-toolkit/src/components/floating-card/styles.module.css
+++ b/packages/design-toolkit/src/components/floating-card/styles.module.css
@@ -33,7 +33,7 @@
   /** The header title is set to a min-width to prevent it from collapsing when the title is long, and truncating the overflow text.  */
   /** Its width is based on the width of the floating card header via a container query, accounting for the padding and other elements in the header. */
   .headerTitle {
-    @apply h-full w-[calc(100cqw-10rem)] truncate align-middle leading-24 @min-[1rem]/floating-card-header:w-[calc(100cqw-10rem)];
+    @apply h-full truncate align-middle leading-24 @min-[1rem]/floating-card-header:w-[calc(100cqw-10rem)];
   }
 
   .floatingCardProvider {

--- a/packages/design-toolkit/src/components/floating-card/styles.module.css
+++ b/packages/design-toolkit/src/components/floating-card/styles.module.css
@@ -22,11 +22,13 @@
   }
 
   .headerSide {
-    @apply gap-xs relative flex h-full items-center;
+    @apply gap-xs flex h-full items-center;
   }
 
+  /* Zero width + pointer-events-none lets the title visually overflow the
+     flex row without consuming drag-handle space or intercepting pointer
+     gestures meant for dockview's drag handle (.dv-void-container). */
   .headerTitleContainer {
-    /** The header title container is set to a width of 0 to maximize the width of the drag handle, which we have no control over (dv-draggable).  */
     @apply text-header-m pl-xs pointer-events-none h-full w-0;
   }
 

--- a/packages/design-toolkit/src/components/floating-card/types.ts
+++ b/packages/design-toolkit/src/components/floating-card/types.ts
@@ -13,16 +13,7 @@
 import type { UniqueId } from '@accelint/core/utility/uuid';
 import type { DockviewApi } from 'dockview-react';
 import type { PropsWithChildren, ReactNode } from 'react';
-
-/**
- * A value that can be static or dynamically computed per floating card.
- *
- * Enables per-card customization of props by passing a factory function
- * that receives the card ID and returns the appropriate value.
- *
- * @template T - The type of the static value or factory return type.
- */
-export type MaybeFactory<T> = T | ((cardId: string) => T);
+import type { MaybeFactory } from './utils';
 
 /**
  * Context value providing floating card management functionality.
@@ -128,30 +119,6 @@ export type FloatingCardHeaderAction =
   | 'pin';
 
 /**
- * Props passed to floating card header components.
- *
- * @remarks Internal type used by header adapters to map Dockview props to custom header components.
- */
-export type FloatingCardHeaderProps = {
-  /** ID of the active floating card panel */
-  id?: string;
-  /** Title text displayed in the header */
-  title?: string;
-  /** Optional icon displayed at the start of the header */
-  icon?: ReactNode;
-  /** Callback to close the entire card group */
-  closeGroup: () => void;
-  /** Toggles pin state for the specified card */
-  togglePinCard?: (id: UniqueId) => void;
-  /** Checks if the specified card is pinned */
-  isPinned?: (id: UniqueId) => boolean;
-  /** Subscribes to pin state changes; returns an unsubscribe function */
-  subscribeToPinState?: (callback: () => void) => () => void;
-  /** Custom action buttons to render in the header */
-  headerActions?: FloatingCardHeaderAction[];
-};
-
-/**
  * Props for the FloatingCardProvider component.
  *
  * Configures default icon and header actions for all floating cards. Both can be
@@ -197,11 +164,3 @@ export type FloatingCardProviderProps = Readonly<
     className?: string;
   }>
 >;
-
-export type HeaderAdapterOptions = {
-  icon?: MaybeFactory<ReactNode>;
-  headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
-  togglePinCard?: (id: UniqueId) => void;
-  isPinned?: (id: UniqueId) => boolean;
-  subscribeToPinState?: (callback: () => void) => () => void;
-};

--- a/packages/design-toolkit/src/components/floating-card/types.ts
+++ b/packages/design-toolkit/src/components/floating-card/types.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { UniqueId } from '@accelint/core/utility/uuid';
+import type { DockviewApi } from 'dockview-react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+/**
+ * A value that can be static or dynamically computed per floating card.
+ *
+ * Enables per-card customization of props by passing a factory function
+ * that receives the card ID and returns the appropriate value.
+ *
+ * @template T - The type of the static value or factory return type.
+ */
+export type MaybeFactory<T> = T | ((cardId: string) => T);
+
+/**
+ * Context value providing floating card management functionality.
+ *
+ * @remarks
+ * Exposed via FloatingCardProvider to child components. Use useFloatingCard() hook to access.
+ */
+export type FloatingCardContextValue = {
+  /** Registry mapping card IDs to their rendered DOM containers */
+  cards: Record<UniqueId, HTMLDivElement>;
+
+  /** Registers a DOM ref for a card container after it mounts */
+  addRef: (id: UniqueId, ref: HTMLDivElement | null) => void;
+
+  /** Unregisters a card's DOM ref when it's removed */
+  removeRef: (view: UniqueId) => void;
+
+  /** Programmatically closes a floating card by ID */
+  closeCard: (id: UniqueId) => void;
+
+  /** Toggles pin state for a floating card, disabling drag when pinned */
+  togglePinCard: (id: UniqueId) => void;
+
+  /** Checks if a floating card is currently pinned */
+  isPinned: (id: UniqueId) => boolean;
+
+  /** Subscribes to pin state changes; returns an unsubscribe function */
+  subscribeToPinState: (callback: () => void) => () => void;
+
+  /** Dockview API instance, null until FloatingCardProvider's onReady fires */
+  api: DockviewApi | null;
+};
+
+/**
+ * Props for the FloatingCard component.
+ *
+ * @example
+ * ```tsx
+ * const props: FloatingCardProps = {
+ *   id: 'panel-123' as UniqueId,
+ *   title: 'My Panel',
+ *   isOpen: true,
+ *   initialDimensions: { width: 350, height: 450 }
+ * };
+ * ```
+ */
+export type FloatingCardProps = Readonly<{
+  /** Unique identifier for the floating card */
+  id: UniqueId;
+  /** Optional title displayed in the floating card header */
+  title?: string;
+  /**
+   * Controls whether the floating card is rendered.
+   *
+   * When `true`, the card registers with the floating card engine and renders its
+   * children via a portal. When `false`, the card is closed and removed.
+   *
+   * @defaultValue true
+   */
+  isOpen?: boolean;
+  /**
+   * Initial dimensions of the floating card panel.
+   *
+   * @defaultValue { width: 300, height: 400 }
+   */
+  initialDimensions?: Readonly<{ width: number; height: number }>;
+  /**
+   * Initial position of the floating card panel.
+   *
+   * When provided, sets the x and y coordinates of the floating card.
+   */
+  initialPosition?: Readonly<{ x: number; y: number }>;
+}>;
+
+/**
+ * Configuration for header action buttons in floating cards.
+ *
+ * Can be a custom button (with icon and onClick), a visual separator ('divider'),
+ * or the built-in pin toggle ('pin').
+ *
+ * @remarks
+ * - Custom buttons: Rendered as icon buttons with your provided onClick handler
+ * - 'divider': Inserts a vertical divider between action groups
+ * - 'pin': Adds built-in pin toggle button (disables dragging when pinned)
+ *
+ * @example
+ * ```tsx
+ * const headerActions: FloatingCardHeaderAction[] = [
+ *   { icon: <SettingsIcon />, onClick: () => openSettings() },
+ *   'divider',
+ *   'pin'
+ * ];
+ * ```
+ */
+export type FloatingCardHeaderAction =
+  | {
+      /** Icon to display in the action button */
+      icon: ReactNode;
+      /** Handler called when the action button is clicked */
+      onClick: () => void;
+    }
+  | 'divider'
+  | 'pin';
+
+/**
+ * Props passed to floating card header components.
+ *
+ * @remarks Internal type used by header adapters to map Dockview props to custom header components.
+ */
+export type FloatingCardHeaderProps = {
+  /** ID of the active floating card panel */
+  id?: string;
+  /** Title text displayed in the header */
+  title?: string;
+  /** Optional icon displayed at the start of the header */
+  icon?: ReactNode;
+  /** Callback to close the entire card group */
+  closeGroup: () => void;
+  /** Toggles pin state for the specified card */
+  togglePinCard?: (id: UniqueId) => void;
+  /** Checks if the specified card is pinned */
+  isPinned?: (id: UniqueId) => boolean;
+  /** Subscribes to pin state changes; returns an unsubscribe function */
+  subscribeToPinState?: (callback: () => void) => () => void;
+  /** Custom action buttons to render in the header */
+  headerActions?: FloatingCardHeaderAction[];
+};
+
+/**
+ * Props for the FloatingCardProvider component.
+ *
+ * Configures default icon and header actions for all floating cards. Both can be
+ * static values or factory functions that receive the card ID for per-card customization.
+ *
+ * @example
+ * ```tsx
+ * <FloatingCardProvider
+ *   icon={<AppIcon />}
+ *   headerActions={(cardId) => {
+ *     if (cardId === 'settings') {
+ *       return [{ icon: <CogIcon />, onClick: openSettings }, 'pin'];
+ *     }
+ *     return ['pin'];
+ *   }}
+ * >
+ *   {children}
+ * </FloatingCardProvider>
+ * ```
+ */
+export type FloatingCardProviderProps = Readonly<
+  PropsWithChildren<{
+    /**
+     * Optional icon rendered at the very start of the floating card header.
+     * Can be a `ReactNode` or a function `(cardId: string) => ReactNode`.
+     */
+    icon?: MaybeFactory<ReactNode>;
+    /**
+     * Optional action buttons rendered in the floating card header before the close button.
+     * Can include `'divider'` to separate groups and `'pin'` to add a pin toggle button.
+     * Can be an array or a function `(cardId: string) => array` to return
+     * per-floating card actions.
+     */
+    headerActions?: MaybeFactory<FloatingCardHeaderAction[]>;
+    /**
+     * Optional set of card IDs that should be pinned when the provider first mounts.
+     *
+     * Like other `initial*` props, this value is only read once at mount time.
+     * Changes after mount have no effect.
+     */
+    initialPinned?: readonly UniqueId[];
+    /** Additional CSS class names for styling */
+    className?: string;
+  }>
+>;
+
+export type HeaderAdapterOptions = {
+  icon?: MaybeFactory<ReactNode>;
+  headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
+  togglePinCard?: (id: UniqueId) => void;
+  isPinned?: (id: UniqueId) => boolean;
+  subscribeToPinState?: (callback: () => void) => () => void;
+};

--- a/packages/design-toolkit/src/components/floating-card/utils.tsx
+++ b/packages/design-toolkit/src/components/floating-card/utils.tsx
@@ -1,0 +1,159 @@
+// __private-exports
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  type FunctionComponent,
+  type ReactNode,
+  useEffect,
+  useState,
+} from 'react';
+import type { UniqueId } from '@accelint/core/utility/uuid';
+import type { IDockviewHeaderActionsProps } from 'dockview-react';
+import type { FloatingCardHeaderAction } from './types';
+
+/**
+ * A value that can be static or dynamically computed per floating card.
+ *
+ * Enables per-card customization of props by passing a factory function
+ * that receives the card ID and returns the appropriate value.
+ *
+ * @template T - The type of the static value or factory return type.
+ */
+export type MaybeFactory<T> = T | ((cardId: string) => T);
+
+/**
+ * Configuration options passed to floating card header adapter functions.
+ *
+ * Used internally by the floating card system to provide header components
+ * with the necessary props and callbacks for rendering customizable headers.
+ *
+ * @remarks
+ * This type is primarily used when creating custom header adapters that need
+ * access to icon, actions, and pin state management from the FloatingCardProvider.
+ *
+ * @example
+ * ```tsx
+ * function createHeaderAdapter(options: HeaderAdapterOptions) {
+ *   return (props: DockviewHeaderProps) => {
+ *     const icon = typeof options.icon === 'function'
+ *       ? options.icon(props.id)
+ *       : options.icon;
+ *     const actions = typeof options.headerActions === 'function'
+ *       ? options.headerActions(props.id)
+ *       : options.headerActions;
+ *
+ *     return (
+ *       <CustomHeader
+ *         icon={icon}
+ *         actions={actions}
+ *         isPinned={options.isPinned?.(props.id)}
+ *         onTogglePin={() => options.togglePinCard?.(props.id)}
+ *       />
+ *     );
+ *   };
+ * }
+ * ```
+ */
+type HeaderAdapterOptions = {
+  icon?: MaybeFactory<ReactNode>;
+  headerActions?: MaybeFactory<FloatingCardHeaderProps['headerActions']>;
+  togglePinCard?: (id: UniqueId) => void;
+  isPinned?: (id: UniqueId) => boolean;
+  subscribeToPinState?: (callback: () => void) => () => void;
+};
+
+/**
+ * Props passed to floating card header components.
+ *
+ * @remarks Internal type used by header adapters to map Dockview props to custom header components.
+ */
+export type FloatingCardHeaderProps = {
+  /** ID of the active floating card panel */
+  id?: string;
+  /** Title text displayed in the header */
+  title?: string;
+  /** Optional icon displayed at the start of the header */
+  icon?: ReactNode;
+  /** Callback to close the entire card group */
+  closeGroup: () => void;
+  /** Toggles pin state for the specified card */
+  togglePinCard?: (id: UniqueId) => void;
+  /** Checks if the specified card is pinned */
+  isPinned?: (id: UniqueId) => boolean;
+  /** Subscribes to pin state changes; returns an unsubscribe function */
+  subscribeToPinState?: (callback: () => void) => () => void;
+  /** Custom action buttons to render in the header */
+  headerActions?: FloatingCardHeaderAction[];
+};
+
+/**
+ * Creates an adapter component to map Dockview's header action props to custom header component props.
+ *
+ * Handles title change subscriptions and resolves MaybeFactory options (icon, headerActions)
+ * either as static values or by invoking factory functions with the active card ID.
+ *
+ * @param Component - The header component to wrap.
+ * @param options - Configuration options including icon and headerActions (static or factory).
+ * @returns Adapter component compatible with Dockview's header API.
+ */
+export function createHeaderAdapter(
+  Component: FunctionComponent<FloatingCardHeaderProps>,
+  options: HeaderAdapterOptions,
+): FunctionComponent<IDockviewHeaderActionsProps> {
+  function HeaderAdapter(props: Readonly<IDockviewHeaderActionsProps>) {
+    const panelId = props.panels[0]?.id ?? '';
+    const [title, setTitle] = useState(props.activePanel?.title);
+
+    useEffect(() => {
+      const panel = props.activePanel;
+
+      if (!panel) {
+        return;
+      }
+
+      setTitle(panel.title);
+
+      const disposable = panel.api.onDidTitleChange(() => {
+        setTitle(panel.title);
+      });
+
+      return () => {
+        disposable.dispose();
+      };
+    }, [props.activePanel]);
+    const icon = props.activePanel
+      ? typeof options?.icon === 'function'
+        ? options.icon(panelId)
+        : options?.icon
+      : undefined;
+    const headerActions =
+      typeof options?.headerActions === 'function'
+        ? options.headerActions(panelId)
+        : options?.headerActions;
+    return (
+      <Component
+        icon={icon}
+        headerActions={headerActions}
+        title={title}
+        id={props.activePanel?.id}
+        closeGroup={() => props.api.close()}
+        togglePinCard={options.togglePinCard}
+        isPinned={options.isPinned}
+        subscribeToPinState={options.subscribeToPinState}
+      />
+    );
+  }
+
+  HeaderAdapter.displayName = `HeaderAdapter(${Component.displayName ?? Component.name ?? 'Anonymous'})`;
+  return HeaderAdapter;
+}

--- a/packages/design-toolkit/src/index.ts
+++ b/packages/design-toolkit/src/index.ts
@@ -268,11 +268,8 @@ export { FloatingCardProvider } from './components/floating-card/provider';
 export type {
   FloatingCardContextValue,
   FloatingCardHeaderAction,
-  FloatingCardHeaderProps,
   FloatingCardProps,
   FloatingCardProviderProps,
-  HeaderAdapterOptions,
-  MaybeFactory,
 } from './components/floating-card/types';
 export { GanttContentContainer } from './components/gantt/components/containers/external/gantt-content-container';
 export { GanttPanelContainer } from './components/gantt/components/containers/external/gantt-panel-container';

--- a/packages/design-toolkit/src/index.ts
+++ b/packages/design-toolkit/src/index.ts
@@ -264,12 +264,16 @@ export type {
   FlashcardProps,
 } from './components/flashcard/types';
 export { FloatingCard } from './components/floating-card';
-export type { FloatingCardProps } from './components/floating-card';
 export { FloatingCardProvider } from './components/floating-card/provider';
 export type {
+  FloatingCardContextValue,
   FloatingCardHeaderAction,
+  FloatingCardHeaderProps,
+  FloatingCardProps,
   FloatingCardProviderProps,
-} from './components/floating-card/provider';
+  HeaderAdapterOptions,
+  MaybeFactory,
+} from './components/floating-card/types';
 export { GanttContentContainer } from './components/gantt/components/containers/external/gantt-content-container';
 export { GanttPanelContainer } from './components/gantt/components/containers/external/gantt-panel-container';
 export { GanttBlock } from './components/gantt/components/content-row/block';


### PR DESCRIPTION
This PR updates the styling in the FloatingCard header so that the title does not obscure the drag handle. 

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

- Open the Floating Card in Storybook.
- Ensure the card is draggable over the title
- Check that the title does not overlap the header actions at any width, and truncates

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information

Before:

https://github.com/user-attachments/assets/67eac727-d529-433d-b34e-7fb807b02200

After:

https://github.com/user-attachments/assets/be1b3786-d3fb-4e50-a8cb-52ca2ed16545





