### PR TITLE
feat: esc while editing shapes cancels

### DIFF
--- a/.changeset/wide-onions-drum.md
+++ b/.changeset/wide-onions-drum.md
@@ -1,0 +1,5 @@
+---
+"@accelint/map-toolkit": minor
+---
+
+Pressing ESC while editing a shape now cancels editing. Previously the editable-layers library only honored Escape in draw modes — transform/translate/rotate/scale modes ignored it.

--- a/packages/map-toolkit/package.json
+++ b/packages/map-toolkit/package.json
@@ -119,6 +119,7 @@
     "./deckgl/shapes/edit-shape-layer/events": "./dist/deckgl/shapes/edit-shape-layer/events.js",
     "./deckgl/shapes/edit-shape-layer/fiber": "./dist/deckgl/shapes/edit-shape-layer/fiber.js",
     "./deckgl/shapes/edit-shape-layer/types": "./dist/deckgl/shapes/edit-shape-layer/types.js",
+    "./deckgl/shapes/edit-shape-layer/use-edit-action-hotkey": "./dist/deckgl/shapes/edit-shape-layer/use-edit-action-hotkey.js",
     "./deckgl/shapes/edit-shape-layer/use-edit-shape": "./dist/deckgl/shapes/edit-shape-layer/use-edit-shape.js",
     "./deckgl/shapes/shared/events": "./dist/deckgl/shapes/shared/events.js",
     "./deckgl/shapes/shared/types": "./dist/deckgl/shapes/shared/types.js",

--- a/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/index.test.tsx
+++ b/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/index.test.tsx
@@ -15,14 +15,21 @@ import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearEditingState, editStore } from './store';
 import type { UniqueId } from '@accelint/core';
+import type {
+  HotkeyConfig,
+  HotkeyManager,
+  HotkeyOptions,
+} from '@accelint/hotkey-manager';
+import type { Mock } from 'vitest';
 import type { Shape } from '../shared/types';
+import type { EditingState } from './types';
 
-// Track hotkey lifecycle calls
-type MockFn = ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>;
-let mockBind: MockFn;
-let mockUnbind: MockFn;
-let mockRegisterHotkey: MockFn;
-let mockUnregisterHotkey: MockFn;
+// Typed mocks so `mock.calls` carries the real argument shape and consumers
+// (e.g. findOnKeyUp) can read `.id` and `.onKeyUp` without casts.
+let mockBind: Mock<() => () => void>;
+let mockUnbind: Mock<() => void>;
+let mockRegisterHotkey: Mock<(options: HotkeyOptions) => HotkeyManager>;
+let mockUnregisterHotkey: Mock<(manager: HotkeyManager) => void>;
 
 // Track icon-config calls
 const mockGetIconConfig = vi.fn();
@@ -30,9 +37,9 @@ const mockGetIconLayerProps = vi.fn();
 
 vi.mock('@accelint/hotkey-manager', () => ({
   globalBind: vi.fn(),
-  Keycode: { Enter: 'Enter', Space: 'Space' },
-  registerHotkey: (...args: unknown[]) => mockRegisterHotkey(...args),
-  unregisterHotkey: (...args: unknown[]) => mockUnregisterHotkey(...args),
+  Keycode: { Enter: 'Enter', Escape: 'Escape', Space: 'Space' },
+  registerHotkey: (options: HotkeyOptions) => mockRegisterHotkey(options),
+  unregisterHotkey: (manager: HotkeyManager) => mockUnregisterHotkey(manager),
 }));
 
 vi.mock('../shared/hooks/use-shift-zoom-disable', () => ({
@@ -46,6 +53,21 @@ vi.mock('../display-shape-layer/utils/icon-config', () => ({
 
 // Import after mocks are set up
 const { EditShapeLayer } = await import('./index');
+
+/** Seed the edit store with a minimal active-editing state for `mapId`. */
+function startEditing(
+  mapId: UniqueId,
+  shape: Shape,
+  overrides: Partial<EditingState> = {},
+) {
+  editStore.set(mapId, {
+    editingShape: shape,
+    editMode: 'point-translate',
+    featureBeingEdited: null,
+    previousMode: null,
+    ...overrides,
+  });
+}
 
 /** Create a minimal shape for testing */
 function createTestShape(
@@ -89,7 +111,8 @@ describe('EditShapeLayer', () => {
     mockBind = vi.fn(() => mockUnbind);
     mockRegisterHotkey = vi.fn(() => ({
       id: 'test-hotkey',
-      config: {},
+      // Tests never read `config`; the real shape has required fields we don't care about.
+      config: {} as HotkeyConfig,
       bind: mockBind,
       forceBind: vi.fn(),
       forceUnbind: vi.fn(),
@@ -117,8 +140,8 @@ describe('EditShapeLayer', () => {
       );
     });
 
-    it('should register and bind hotkeys on mount', () => {
-      const { unmount } = render(<EditShapeLayer mapId={mapId} />);
+    it('should wire up the expected hotkeys on mount', () => {
+      render(<EditShapeLayer mapId={mapId} />);
 
       expect(mockRegisterHotkey).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -128,13 +151,17 @@ describe('EditShapeLayer', () => {
       );
       expect(mockRegisterHotkey).toHaveBeenCalledWith(
         expect.objectContaining({
+          id: `cancelEditHotkey-${mapId}`,
+          key: { code: 'Escape' },
+        }),
+      );
+      expect(mockRegisterHotkey).toHaveBeenCalledWith(
+        expect.objectContaining({
           id: `editPanningHotkey-${mapId}`,
           key: { code: 'Space' },
         }),
       );
       expect(mockBind).toHaveBeenCalled();
-
-      unmount();
     });
 
     it('should unbind and unregister hotkeys on unmount', () => {
@@ -165,6 +192,62 @@ describe('EditShapeLayer', () => {
     });
   });
 
+  describe('keyboard shortcuts', () => {
+    /**
+     * Grab the onKeyUp handler the component registered for `hotkeyId`.
+     * Throws if the hotkey isn't registered so tests fail loudly at the
+     * setup boundary rather than silently invoking `undefined?.()`.
+     */
+    function findOnKeyUp(hotkeyId: string): () => void {
+      const match = mockRegisterHotkey.mock.calls.find(
+        ([options]) => options.id === hotkeyId,
+      );
+      if (!match?.[0].onKeyUp) {
+        throw new Error(
+          `No onKeyUp handler registered for hotkey "${hotkeyId}"`,
+        );
+      }
+      // The handler passed by useEditActionHotkey ignores event/key/hotkey
+      // args; narrow HotkeyAction to () => void so tests can invoke it like
+      // a synthetic key-up without fabricating a KeyboardEvent.
+      return match[0].onKeyUp as () => void;
+    }
+
+    it('should save editing when Enter is released while a shape is being edited', () => {
+      const shape = createTestShape();
+      startEditing(mapId, shape, { featureBeingEdited: shape.feature });
+
+      render(<EditShapeLayer mapId={mapId} />);
+
+      findOnKeyUp(`saveEditHotkey-${mapId}`)();
+
+      // Save clears editing state once the session completes.
+      expect(editStore.get(mapId)?.editingShape).toBeNull();
+    });
+
+    it('should cancel editing when Escape is released while a shape is being edited', () => {
+      const shape = createTestShape();
+      startEditing(mapId, shape);
+
+      render(<EditShapeLayer mapId={mapId} />);
+
+      findOnKeyUp(`cancelEditHotkey-${mapId}`)();
+
+      expect(editStore.get(mapId)?.editingShape).toBeNull();
+    });
+
+    it('should no-op on Escape when no shape is being edited', () => {
+      render(<EditShapeLayer mapId={mapId} />);
+
+      const onEscapeUp = findOnKeyUp(`cancelEditHotkey-${mapId}`);
+
+      // Invoking with no active edit should not throw or populate the store.
+      expect(() => onEscapeUp()).not.toThrow();
+      const editingShape = editStore.get(mapId)?.editingShape ?? null;
+      expect(editingShape).toBeNull();
+    });
+  });
+
   describe('icon-point editing', () => {
     it('should call getIconConfig with the editing shape feature', () => {
       const shape = createTestShape({
@@ -174,18 +257,11 @@ describe('EditShapeLayer', () => {
         size: 32,
       });
 
-      editStore.set(mapId, {
-        editingShape: shape,
-        editMode: 'point-translate',
-        featureBeingEdited: null,
-        previousMode: null,
-      });
+      startEditing(mapId, shape);
 
-      const { unmount } = render(<EditShapeLayer mapId={mapId} />);
+      render(<EditShapeLayer mapId={mapId} />);
 
       expect(mockGetIconConfig).toHaveBeenCalledWith([shape.feature]);
-
-      unmount();
     });
 
     it('should call getIconLayerProps when icons are detected', () => {
@@ -206,22 +282,15 @@ describe('EditShapeLayer', () => {
         iconMapping: TEST_MAPPING,
       });
 
-      editStore.set(mapId, {
-        editingShape: shape,
-        editMode: 'point-translate',
-        featureBeingEdited: null,
-        previousMode: null,
-      });
+      startEditing(mapId, shape);
 
-      const { unmount } = render(<EditShapeLayer mapId={mapId} />);
+      render(<EditShapeLayer mapId={mapId} />);
 
       expect(mockGetIconLayerProps).toHaveBeenCalledWith(
         true,
         TEST_ATLAS,
         TEST_MAPPING,
       );
-
-      unmount();
     });
 
     it('should not call getIconLayerProps when no icons are detected', () => {
@@ -229,18 +298,11 @@ describe('EditShapeLayer', () => {
 
       mockGetIconConfig.mockReturnValue({ hasIcons: false });
 
-      editStore.set(mapId, {
-        editingShape: shape,
-        editMode: 'point-translate',
-        featureBeingEdited: null,
-        previousMode: null,
-      });
+      startEditing(mapId, shape);
 
-      const { unmount } = render(<EditShapeLayer mapId={mapId} />);
+      render(<EditShapeLayer mapId={mapId} />);
 
       expect(mockGetIconLayerProps).not.toHaveBeenCalled();
-
-      unmount();
     });
   });
 });

--- a/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/index.tsx
+++ b/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/index.tsx
@@ -43,6 +43,7 @@ import {
   saveEditingFromLayer,
   updateFeature,
 } from './store';
+import { useEditActionHotkey } from './use-edit-action-hotkey';
 import type {
   EditAction,
   FeatureCollection,
@@ -183,10 +184,6 @@ export function EditShapeLayer({
     rafId: number;
   } | null>(null);
 
-  // Keep a ref to the latest editing state so the hotkey handler can access it
-  const editingStateRef = useRef(editingState);
-  editingStateRef.current = editingState;
-
   // Ensure global hotkey listeners are initialized
   // Safe to call multiple times - globalBind() checks if already bound
   useEffect(() => {
@@ -201,28 +198,27 @@ export function EditShapeLayer({
     }
   }, []);
 
-  // Register Enter key hotkey scoped to this component and map instance.
-  // Handles the full lifecycle: register → bind → unbind → unregister.
-  // Without unregistering on cleanup, remounting throws a duplicate-id error.
-  useEffect(() => {
-    const manager = registerHotkey({
-      id: `saveEditHotkey-${actualMapId}`,
-      key: { code: Keycode.Enter },
-      onKeyUp: () => {
-        if (editingStateRef.current?.editingShape) {
-          cancelPendingUpdate();
-          saveEditingFromLayer(actualMapId);
-        }
-      },
-    });
+  // Save on Enter.
+  useEditActionHotkey({
+    mapId: actualMapId,
+    id: 'saveEditHotkey',
+    keyCode: Keycode.Enter,
+    action: saveEditingFromLayer,
+    cancelPendingUpdate,
+    editingState,
+  });
 
-    const unbind = manager.bind();
-
-    return () => {
-      unbind();
-      unregisterHotkey(manager);
-    };
-  }, [actualMapId, cancelPendingUpdate]);
+  // Cancel on Escape. The editable-layers library only emits `cancelFeature`
+  // for draw modes — transform/translate/rotate/scale modes ignore Escape —
+  // so the edit layer registers its own handler.
+  useEditActionHotkey({
+    mapId: actualMapId,
+    id: 'cancelEditHotkey',
+    keyCode: Keycode.Escape,
+    action: cancelEditingFromLayer,
+    cancelPendingUpdate,
+    editingState,
+  });
 
   // Register Space key for enabling panning while editing shape.
   // NOTE: Low threshold (50ms) enables near-instant panning response on hold.

--- a/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/use-edit-action-hotkey.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/edit-shape-layer/use-edit-action-hotkey.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use client';
+
+import 'client-only';
+import { useEffectEvent } from '@accelint/bus/react';
+import {
+  type Keycode,
+  registerHotkey,
+  unregisterHotkey,
+} from '@accelint/hotkey-manager';
+import { useEffect } from 'react';
+import type { UniqueId } from '@accelint/core';
+import type { EditingState } from './types';
+
+export type EditActionHotkeyOptions = {
+  /** Map instance the hotkey is scoped to. */
+  mapId: UniqueId;
+  /** Hotkey-manager id prefix; the hook appends `-${mapId}` to build the full id. */
+  id: string;
+  /** Keyboard code that triggers the action (e.g. `Keycode.Enter`). */
+  keyCode: Keycode;
+  /** Edit-store action to dispatch on key-up while editing (e.g. save / cancel). */
+  action: (mapId: UniqueId) => void;
+  /** Cancels any pending RAF batch before the action fires. */
+  cancelPendingUpdate: () => void;
+  /** Current edit session; handler no-ops when no shape is being edited. */
+  editingState: EditingState | null;
+};
+
+/**
+ * Registers a keyUp hotkey that fires an edit-store action while a shape is
+ * being edited. Shared between the Save (Enter) and Cancel (Escape) bindings;
+ * both follow the same guard-and-dispatch shape and lifecycle (register →
+ * bind → unbind → unregister). Remounting without unregistering throws a
+ * duplicate-id error, so the cleanup is mandatory.
+ *
+ * `useEffectEvent` keeps the keyUp handler referentially stable so the effect
+ * only re-subscribes when the hotkey identity changes (`mapId`/`id`/`keyCode`),
+ * while still calling the latest closure over `editingState` at key-press time.
+ */
+export function useEditActionHotkey({
+  mapId,
+  id,
+  keyCode,
+  action,
+  cancelPendingUpdate,
+  editingState,
+}: EditActionHotkeyOptions): void {
+  const handleKeyUp = useEffectEvent(() => {
+    if (editingState?.editingShape) {
+      cancelPendingUpdate();
+      action(mapId);
+    }
+  });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: handleKeyUp is stable via useEffectEvent.
+  useEffect(() => {
+    const manager = registerHotkey({
+      id: `${id}-${mapId}`,
+      key: { code: keyCode },
+      onKeyUp: handleKeyUp,
+    });
+
+    const unbind = manager.bind();
+
+    return () => {
+      unbind();
+      unregisterHotkey(manager);
+    };
+  }, [mapId, id, keyCode]);
+}


### PR DESCRIPTION
Closes no ticket

While working on the shapes recipes, I noticed that there was a discrepancy between the drawing and editing behavior while pushing ESC and Enter. While drawing, the editable layer from deck.gl cancels draw on ESC and saves on Enter. We previously had partially mirrored this behavior manually when editing by matching the save on Enter behavior, but neglected to match the cancel on ESC behavior. This PR fixes that discrepancy

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

- preview map tk
- head to any of the editing stories
- edit a shape
- press cancel
- notice your edits are canceled and the shape resumes to the previous state

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [x] Ideation / brainstorming
- [x] Documentation
- [x] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
