### PR TITLE
fix: prevent stale tooltip on next draw

### DIFF
--- a/.changeset/vast-candles-lay.md
+++ b/.changeset/vast-candles-lay.md
@@ -1,0 +1,5 @@
+---
+"@accelint/map-toolkit": patch
+---
+
+Draw shapes layer no longer shows stale tooltip until first mouse event (bug) on subsequent draw actions.

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-circle-mode-with-tooltip.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-circle-mode-with-tooltip.ts
@@ -94,6 +94,18 @@ export class DrawCircleModeWithTooltip extends DrawCircleFromCenterMode {
   }
 
   /**
+   * Reset the click sequence and clear the tooltip together.
+   *
+   * The mode instance is cached and reused across draw sessions, so without
+   * this override `this.tooltip` would persist from one session into the next
+   * and flash before `handlePointerMove` overwrites it.
+   */
+  override resetClickSequence(): void {
+    super.resetClickSequence();
+    this.tooltip = null;
+  }
+
+  /**
    * Get the current tooltip array for rendering.
    *
    * @returns Array containing the tooltip if one is active, empty array otherwise

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-ellipse-mode-with-tooltip.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-ellipse-mode-with-tooltip.ts
@@ -146,4 +146,16 @@ export class DrawEllipseModeWithTooltip extends DrawEllipseUsingThreePointsMode 
   override getTooltips(): Tooltip[] {
     return this.tooltip ? [this.tooltip] : [];
   }
+
+  /**
+   * Reset the click sequence and clear the tooltip together.
+   *
+   * The mode instance is cached and reused across draw sessions, so without
+   * this override `this.tooltip` would persist from one session into the next
+   * and flash before `handlePointerMove` overwrites it.
+   */
+  override resetClickSequence(): void {
+    super.resetClickSequence();
+    this.tooltip = null;
+  }
 }

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-line-string-mode-with-tooltip.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-line-string-mode-with-tooltip.ts
@@ -143,4 +143,16 @@ export class DrawLineStringModeWithTooltip extends DrawLineStringMode {
   override getTooltips(): Tooltip[] {
     return this.tooltip ? [this.tooltip] : [];
   }
+
+  /**
+   * Reset the click sequence and clear the tooltip together.
+   *
+   * The mode instance is cached and reused across draw sessions, so without
+   * this override `this.tooltip` would persist from one session into the next
+   * and flash before `handlePointerMove` overwrites it.
+   */
+  override resetClickSequence(): void {
+    super.resetClickSequence();
+    this.tooltip = null;
+  }
 }

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-polygon-mode-with-tooltip.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-polygon-mode-with-tooltip.ts
@@ -130,4 +130,16 @@ export class DrawPolygonModeWithTooltip extends DrawPolygonMode {
   override getTooltips(): Tooltip[] {
     return this.tooltip ? [this.tooltip] : [];
   }
+
+  /**
+   * Reset the click sequence and clear the tooltip together.
+   *
+   * The mode instance is cached and reused across draw sessions, so without
+   * this override `this.tooltip` would persist from one session into the next
+   * and flash before `handlePointerMove` overwrites it.
+   */
+  override resetClickSequence(): void {
+    super.resetClickSequence();
+    this.tooltip = null;
+  }
 }

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-rectangle-mode-with-tooltip.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/draw-rectangle-mode-with-tooltip.ts
@@ -212,4 +212,16 @@ export class DrawRectangleModeWithTooltip extends DrawRectangleMode {
   override getTooltips(): Tooltip[] {
     return this.tooltip ? [this.tooltip] : [];
   }
+
+  /**
+   * Reset the click sequence and clear the tooltip together.
+   *
+   * The mode instance is cached and reused across draw sessions, so without
+   * this override `this.tooltip` would persist from one session into the next
+   * and flash before `handlePointerMove` overwrites it.
+   */
+  override resetClickSequence(): void {
+    super.resetClickSequence();
+    this.tooltip = null;
+  }
 }

--- a/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/modes.test.ts
+++ b/packages/map-toolkit/src/deckgl/shapes/draw-shape-layer/modes/modes.test.ts
@@ -125,6 +125,40 @@ describe('Draw Mode Classes', () => {
   });
 });
 
+describe('Tooltip lifecycle', () => {
+  /**
+   * Mode instances are cached and reused across draw sessions, so the
+   * private `tooltip` field would otherwise leak from one session into the
+   * next render frame. The `resetClickSequence` override clears it.
+   *
+   * We poke the private field directly because the alternative (driving a
+   * full `handlePointerMove` cycle with synthetic event/props) tests more
+   * than the override and adds significant setup; the field is the exact
+   * lifecycle state under test.
+   */
+  type WithPrivateTooltip = {
+    tooltip: { position: [number, number]; text: string } | null;
+  };
+
+  it.each([
+    ['Circle', () => new DrawCircleModeWithTooltip()],
+    ['Polygon', () => new DrawPolygonModeWithTooltip()],
+    ['LineString', () => new DrawLineStringModeWithTooltip()],
+    ['Rectangle', () => new DrawRectangleModeWithTooltip()],
+    ['Ellipse', () => new DrawEllipseModeWithTooltip()],
+  ])('%s clears tooltip when click sequence is reset', (_label, factory) => {
+    const mode = factory();
+    const stale = { position: [0, 0] as [number, number], text: 'stale' };
+
+    (mode as unknown as WithPrivateTooltip).tooltip = stale;
+    expect(mode.getTooltips()).toEqual([stale]);
+
+    mode.resetClickSequence();
+
+    expect(mode.getTooltips()).toEqual([]);
+  });
+});
+
 describe('Mode Instance Functions', () => {
   describe('getModeInstance', () => {
     it('returns cached mode instance for Circle', () => {


### PR DESCRIPTION
Closes no ticket.

While working on the rectangle recipe, I noticed that the last tooltip position / text would blip on subsequent draw events for new shapes. This PR fixes that issue by setting tooltip to null in the resetClickSequence method that is called internally by deck.gl editable layer when drawing ends.

### Before

<img width="1338" height="892" alt="tooltip-blip-before" src="https://github.com/user-attachments/assets/db0e94ee-52b8-4473-bfd6-db75a809b40f" />

### After

<img width="1338" height="892" alt="tooltip-blip-after" src="https://github.com/user-attachments/assets/41252385-1ca9-4766-b98a-1be762d5577e" />

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

* preview mtk
* go to the basic draw shapes story
* draw a circle twice
* notice that no tooltip from the first circle appears when you begin drawing the second one
* go to main branch
* repeat
* notice the bug

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [ ] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
