### PR TITLE
feat: expose available maplibre options to consumers

### DIFF
--- a/.changeset/maplibre-options.md
+++ b/.changeset/maplibre-options.md
@@ -1,0 +1,24 @@
+---
+"@accelint/map-toolkit": minor
+---
+
+Adds a `mapLibreOptions` prop to `BaseMap` that forwards additional MapLibre `MapOptions` (e.g. `transformRequest`, `maxBounds`, `minZoom`/`maxZoom`, `locale`, `interactive`, `cooperativeGestures`) to the underlying map instance.
+
+The most common use is `transformRequest` for rewriting tile URLs through a proxy, adding auth headers, or resolving `mapbox://` URIs against a self-hosted Mapbox-compatible service.
+
+```tsx
+<BaseMap
+  id={MAIN_MAP_ID}
+  styleUrl={MAPBOX_STYLE_URL}
+  mapLibreOptions={{
+    transformRequest: (url) =>
+      url.startsWith('mapbox://')
+        ? { url: url.replace('mapbox://', 'https://tiles.internal.example.com/') }
+        : { url },
+    maxBounds: [[-130, 20], [-60, 55]],
+    cooperativeGestures: true,
+  }}
+/>
+```
+
+Keys BaseMap manages internally are silently stripped before being applied: camera/view state (`container`, `center`, `bounds`, `fitBoundsOptions`, `zoom`, `pitch`, `bearing`, `projection`, `maxPitch`), gestures reserved for Deck.gl picking and the camera state machine (`doubleClickZoom`, `dragRotate`, `pitchWithRotate`, `rollEnabled`), the WebGL context (`canvasContextAttributes`), and keys already exposed as dedicated BaseMap props (`boxZoom`, `style`).

--- a/packages/map-toolkit/src/deckgl/base-map/base-map.docs.mdx
+++ b/packages/map-toolkit/src/deckgl/base-map/base-map.docs.mdx
@@ -46,7 +46,6 @@ pnpm add @accelint/map-toolkit @accelint/bus @deck.gl/core @deckgl-fiber-rendere
 
 ```typescript
 import { BaseMap } from '@accelint/map-toolkit/deckgl';
-import { View } from '@deckgl-fiber-renderer/dom';
 import { uuid } from '@accelint/core';
 
 // Module-level constant for stability
@@ -55,7 +54,6 @@ const MAIN_MAP_ID = uuid();
 export function MapView() {
   return (
     <BaseMap id={MAIN_MAP_ID} className="w-full h-full">
-      <View id="main" controller />
       {/* Add your Deck.gl layers here */}
     </BaseMap>
   );
@@ -69,7 +67,6 @@ UI components (toolbars, buttons, etc.) should be rendered as **siblings** to Ba
 ```typescript
 import { BaseMap } from '@accelint/map-toolkit/deckgl';
 import { useMapMode } from '@accelint/map-toolkit/map-mode';
-import { View } from '@deckgl-fiber-renderer/dom';
 import { uuid } from '@accelint/core';
 
 // Module-level constant shared across components
@@ -92,7 +89,6 @@ export function InteractiveMap() {
   return (
     <div className="relative w-full h-full">
       <BaseMap id={MAIN_MAP_ID} className="absolute inset-0">
-        <View id="main" controller />
         {/* Only Deck.gl layers as children */}
       </BaseMap>
       <Toolbar />
@@ -127,9 +123,7 @@ export function InteractiveMap() {
       className="w-full h-full"
       onClick={handleClick}
       onHover={handleHover}
-    >
-      <View id="main" controller />
-    </BaseMap>
+    />
   );
 }
 ```
@@ -167,6 +161,7 @@ The `BaseMap` component extends all `DeckglProps` from `@deckgl-fiber-renderer/t
 | `boxZoom` | `boolean` | `!enableRbz` | Enable MapLibre's native box zoom gesture (Shift + drag). Defaults to `true`, or `false` when `enableRbz` is `true` (the two gestures conflict). |
 | `enableRbz` | `boolean` | `false` | Enable rubber band zoom. See [Rubber Band Zoom](#rubber-band-zoom). |
 | `rbzOptions` | [`RbzOptions`](?path=/docs/deckgl-rubber-band-zoom--docs) | `undefined` | Configuration for rubber band zoom. Only applies when `enableRbz` is `true`. |
+| `mapLibreOptions` | [`MapLibreOptions`](#forwarding-maplibre-options) | `undefined` | Additional MapLibre `MapOptions` forwarded to the underlying map (e.g. `transformRequest`, `maxBounds`, `minZoom`, `maxZoom`, `locale`, `interactive`, `cooperativeGestures`). Locked keys are stripped. |
 
 All `DeckglProps` (including `onClick`, `onHover`, `parameters`, `initialViewState`, `controller`, `widgets`, etc.) are also accepted and forwarded to Deck.gl. See the [Deck.gl documentation](https://deck.gl/docs/api-reference/core/deck) for the full set.
 
@@ -218,14 +213,10 @@ function MapView() {
 import { BaseMap, LIGHT_BASE_MAP_STYLE } from '@accelint/map-toolkit/deckgl';
 
 // Light theme
-<BaseMap id={mapId} styleUrl={LIGHT_BASE_MAP_STYLE}>
-  <View id="main" controller />
-</BaseMap>
+<BaseMap id={mapId} styleUrl={LIGHT_BASE_MAP_STYLE} />
 
 // Custom style URL
-<BaseMap id={mapId} styleUrl="https://your-custom-style.json">
-  <View id="main" controller />
-</BaseMap>
+<BaseMap id={mapId} styleUrl="https://your-custom-style.json" />
 ```
 
 #### Rubber Band Zoom
@@ -248,6 +239,47 @@ When `enableRbz` is `true`, BaseMap creates an [`RbzHandler`](?path=/docs/deckgl
 > **`enableRbz` and `rbzOptions` are read once on map load.** Changes after mount have no effect. To toggle or reconfigure dynamically, change the map's `key` prop to force a remount.
 
 See the [Rubber Band Zoom docs](?path=/docs/deckgl-rubber-band-zoom--docs) for the full RBZ API surface.
+
+#### Forwarding MapLibre options
+
+`mapLibreOptions` forwards arbitrary MapLibre options to the underlying map — anything not in the [Stripped keys](#stripped-keys) list below is passed straight through. The type is `MapLibreOptions` (exported from `@accelint/map-toolkit/deckgl`), which is `Partial<MapOptions>` with BaseMap-managed keys omitted. Defaults BaseMap sets (e.g. `attributionControl: { compact: true }`) can be overridden by including the same key.
+
+The most common use is `transformRequest` for rewriting tile URLs through a proxy, adding auth headers, or resolving `mapbox://` URIs against a self-hosted Mapbox-compatible service:
+
+```tsx
+import { BaseMap } from '@accelint/map-toolkit/deckgl';
+
+<BaseMap
+  id={MAIN_MAP_ID}
+  styleUrl={MAPBOX_STYLE_URL}
+  mapLibreOptions={{
+    transformRequest: (url, resourceType) => {
+      if (url.startsWith('mapbox://')) {
+        return {
+          url: url.replace('mapbox://', 'https://tiles.internal.example.com/'),
+        };
+      }
+      return { url };
+    },
+    maxBounds: [[-130, 20], [-60, 55]],
+    minZoom: 2,
+    maxZoom: 18,
+    locale: { 'AttributionControl.ToggleAttribution': 'Toggle attribution' },
+    cooperativeGestures: true,
+  }}
+/>
+```
+
+##### Stripped keys
+
+The following keys are silently removed before being applied to MapLibre. They're either derived from BaseMap's camera/view state, required by Deck.gl picking/interaction, already exposed as dedicated BaseMap props, or unsupported by the underlying `react-map-gl` wrapper:
+
+- Camera/view state: `container`, `center`, `bounds`, `fitBoundsOptions`, `zoom`, `pitch`, `bearing`, `projection`, `maxPitch`
+- Locked gestures (reserved for Deck.gl picking and the camera state machine): `doubleClickZoom`, `dragRotate`, `pitchWithRotate`, `rollEnabled`
+- Locked rendering config: `canvasContextAttributes`
+- Already a dedicated BaseMap prop: `boxZoom` (use the `boxZoom` prop), `style` (use `styleUrl`)
+
+If you need to override one of these, use the corresponding BaseMap prop or file an issue describing the use case.
 
 ### Exported Constants
 
@@ -301,7 +333,7 @@ Event names for map interactions:
 
 ## Children Components
 
-**Important**: BaseMap passes its children directly to Deck.gl's rendering engine, which only accepts Deck.gl layer components (e.g., `<View>`, `<ScatterplotLayer>`, etc.).
+**Important**: BaseMap passes its children directly to Deck.gl's rendering engine, which only accepts Deck.gl layer components (e.g., `<ScatterplotLayer>`, `<symbolLayer>`, etc.).
 
 **Do NOT** render regular React UI components (buttons, divs, toolbars, etc.) as children of BaseMap. Doing so will result in errors like "Text nodes are not supported."
 
@@ -311,7 +343,6 @@ Event names for map interactions:
 // ✅ Correct - UI as siblings
 <div className="relative w-full h-full">
   <BaseMap id={mapId} className="absolute inset-0">
-    <View id="main" controller />
     {/* Only Deck.gl layers */}
   </BaseMap>
   <Toolbar /> {/* Sibling to BaseMap */}

--- a/packages/map-toolkit/src/deckgl/base-map/index.test.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.test.tsx
@@ -13,7 +13,10 @@
 import { uuid } from '@accelint/core';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { BaseMap } from './index';
+import { BaseMap, stripLockedMapLibreOptions } from './index';
+import { LOCKED_MAP_LIBRE_OPTION_KEYS } from './types';
+import type { MapOptions } from 'maplibre-gl';
+import type { MapLibreOptions } from './types';
 
 // Mock MapLibre hook since it requires browser APIs
 vi.mock('../../maplibre/hooks/use-maplibre', () => ({
@@ -33,5 +36,105 @@ describe('BaseMap', () => {
     );
 
     expect(container.firstChild).toHaveClass('custom-map-class');
+  });
+});
+
+describe('stripLockedMapLibreOptions', () => {
+  // Type alias for tests that need to inject keys outside the public
+  // `MapLibreOptions` surface (which omits locked keys). Casts via `unknown`
+  // are required to exercise the function's defensive behavior against
+  // runtime inputs that include locked keys.
+  type UnsafeInput = Partial<MapOptions>;
+
+  it('should return an empty object when input is undefined', () => {
+    const result = stripLockedMapLibreOptions(undefined);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return an empty object when input is empty', () => {
+    const result = stripLockedMapLibreOptions({});
+
+    expect(result).toEqual({});
+  });
+
+  it('should pass through non-locked keys unchanged', () => {
+    const transformRequest: NonNullable<MapOptions['transformRequest']> = (
+      url,
+    ) => ({ url });
+    const input: MapLibreOptions = {
+      transformRequest,
+      maxBounds: [
+        [-130, 20],
+        [-60, 55],
+      ],
+      minZoom: 2,
+      maxZoom: 18,
+      locale: { 'AttributionControl.ToggleAttribution': 'Toggle' },
+    };
+
+    const result = stripLockedMapLibreOptions(input);
+
+    expect(result).toEqual(input);
+  });
+
+  it.each(
+    LOCKED_MAP_LIBRE_OPTION_KEYS,
+  )('should strip locked key %s', (lockedKey) => {
+    const unsafe: UnsafeInput = { [lockedKey]: 'arbitrary' };
+    const input = unsafe as unknown as MapLibreOptions;
+
+    const result = stripLockedMapLibreOptions(input);
+
+    expect(result).toEqual({});
+  });
+
+  it('should preserve reference equality for passthrough values', () => {
+    const transformRequest: NonNullable<MapOptions['transformRequest']> = (
+      url,
+    ) => ({ url });
+
+    const result = stripLockedMapLibreOptions({ transformRequest });
+
+    expect(result.transformRequest).toBe(transformRequest);
+  });
+
+  it('should keep only passthrough keys when input mixes locked and passthrough', () => {
+    const transformRequest: NonNullable<MapOptions['transformRequest']> = (
+      url,
+    ) => ({ url });
+    const unsafe: UnsafeInput = {
+      transformRequest,
+      container: 'evil-container',
+      zoom: 99,
+      maxBounds: [
+        [-130, 20],
+        [-60, 55],
+      ],
+    };
+    const input = unsafe as unknown as MapLibreOptions;
+
+    const result = stripLockedMapLibreOptions(input);
+
+    expect(result).toEqual({
+      transformRequest,
+      maxBounds: [
+        [-130, 20],
+        [-60, 55],
+      ],
+    });
+  });
+
+  it('should not mutate the input object', () => {
+    const transformRequest: NonNullable<MapOptions['transformRequest']> = (
+      url,
+    ) => ({ url });
+    const unsafe: UnsafeInput = { transformRequest, container: 'evil' };
+    const input = unsafe as unknown as MapLibreOptions;
+    const snapshot = { ...input };
+
+    stripLockedMapLibreOptions(input);
+
+    expect(input).toEqual(snapshot);
   });
 });

--- a/packages/map-toolkit/src/deckgl/base-map/index.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.tsx
@@ -33,12 +33,18 @@ import { DARK_BASE_MAP_STYLE, PARAMETERS, PICKING_RADIUS } from './constants';
 import { MapControls } from './controls';
 import { MapEvents } from './events';
 import { MapProvider } from './provider';
-import type { IControl, WebGLContextAttributesWithType } from 'maplibre-gl';
+import { LOCKED_MAP_LIBRE_OPTION_KEYS } from './types';
+import type {
+  IControl,
+  MapOptions,
+  WebGLContextAttributesWithType,
+} from 'maplibre-gl';
 import type { MjolnirGestureEvent, MjolnirPointerEvent } from 'mjolnir.js';
 import type {
   BaseMapProps,
   MapClickEvent,
   MapHoverEvent,
+  MapLibreOptions,
   MapViewportEvent,
   SerializablePickingInfo,
 } from './types';
@@ -52,6 +58,39 @@ const CANVAS_CONTEXT_ATTRIBUTES: WebGLContextAttributesWithType = {
   contextType: 'webgl2',
 } as const;
 
+const DEFAULT_ATTRIBUTION_CONTROL: MapOptions['attributionControl'] = {
+  compact: true,
+};
+
+const LOCKED_MAP_LIBRE_OPTION_KEY_SET: ReadonlySet<string> = new Set(
+  LOCKED_MAP_LIBRE_OPTION_KEYS,
+);
+
+/**
+ * Removes locked keys from `mapLibreOptions` before they reach the underlying
+ * MapLibre instance. Locked keys are either derived from BaseMap's camera/view
+ * state, required by Deck.gl picking/interaction, or already exposed as
+ * dedicated BaseMap props.
+ *
+ * @internal Exported solely for unit testing. Not part of the public API.
+ */
+export function stripLockedMapLibreOptions(
+  options: MapLibreOptions | undefined,
+): MapLibreOptions {
+  if (!options) {
+    return {};
+  }
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(options)) {
+    if (!LOCKED_MAP_LIBRE_OPTION_KEY_SET.has(key)) {
+      result[key] = value;
+    }
+  }
+
+  return result as MapLibreOptions;
+}
+
 /**
  * Serializes PickingInfo for event bus transmission by removing non-cloneable properties.
  * Omits viewport, layer, and sourceLayer (contain functions) but preserves layer IDs.
@@ -61,6 +100,7 @@ const CANVAS_CONTEXT_ATTRIBUTES: WebGLContextAttributesWithType = {
  */
 function serializePickingInfo(info: PickingInfo): SerializablePickingInfo {
   const { viewport, layer, sourceLayer, ...infoRest } = info;
+
   return {
     layerId: layer?.id,
     sourceLayerId: sourceLayer?.id,
@@ -124,6 +164,7 @@ function serializeMjolnirEvent(
   // Remove pointer arrays if present (only on MjolnirGestureEvent)
   if ('changedPointers' in rest) {
     const { changedPointers, pointers, ...gestureRest } = rest;
+
     return gestureRest;
   }
 
@@ -167,18 +208,13 @@ function AddDeckglControl() {
  * ```tsx
  * // Basic usage with id (recommended: module-level constant)
  * import { BaseMap } from '@accelint/map-toolkit/deckgl';
- * import { View } from '@deckgl-fiber-renderer/dom';
  * import { uuid } from '@accelint/core';
  *
  * // Create id at module level for stability and easy sharing
  * const MAIN_MAP_ID = uuid();
  *
  * export function MapView() {
- *   return (
- *     <BaseMap className="w-full h-full" id={MAIN_MAP_ID}>
- *       <View id="main" controller />
- *     </BaseMap>
- *   );
+ *   return <BaseMap className="w-full h-full" id={MAIN_MAP_ID} />;
  * }
  * ```
  *
@@ -207,9 +243,11 @@ function AddDeckglControl() {
  *
  *   return (
  *     <div className="relative w-full h-full">
- *       <BaseMap className="absolute inset-0" id={MAIN_MAP_ID} onClick={handleClick}>
- *         <View id="main" controller />
- *       </BaseMap>
+ *       <BaseMap
+ *         className="absolute inset-0"
+ *         id={MAIN_MAP_ID}
+ *         onClick={handleClick}
+ *       />
  *       <Toolbar />
  *     </div>
  *   );
@@ -236,6 +274,7 @@ export function BaseMap({
   enableRbz = false,
   rbzOptions,
   boxZoom: boxZoomProp,
+  mapLibreOptions,
   ...rest
 }: BaseMapProps) {
   const mapGeneration = getMapGeneration(id);
@@ -265,9 +304,16 @@ export function BaseMap({
     [cameraState],
   );
 
-  // Memoize MapLibre options to avoid creating new object on every render
+  const filteredMapLibreOptions = useMemo(
+    () => stripLockedMapLibreOptions(mapLibreOptions),
+    [mapLibreOptions],
+  );
+
+  // Spread order: default → consumer overrides → locked keys (last wins).
   const mapOptions = useMemo(
     () => ({
+      attributionControl: DEFAULT_ATTRIBUTION_CONTROL,
+      ...filteredMapLibreOptions,
       container,
       zoom: viewState.zoom,
       pitch: viewState.pitch,
@@ -278,13 +324,19 @@ export function BaseMap({
       dragRotate: false,
       pitchWithRotate: false,
       rollEnabled: false,
-      attributionControl: { compact: true },
       projection: cameraState.projection,
       maxPitch: cameraState.view === '2D' ? 0 : 85,
       canvasContextAttributes: CANVAS_CONTEXT_ATTRIBUTES,
       boxZoom,
     }),
-    [viewState, container, cameraState.projection, cameraState.view, boxZoom],
+    [
+      viewState,
+      container,
+      cameraState.projection,
+      cameraState.view,
+      boxZoom,
+      filteredMapLibreOptions,
+    ],
   );
 
   const emitClick = useEmit<MapClickEvent>(MapEvents.click);

--- a/packages/map-toolkit/src/deckgl/base-map/types.ts
+++ b/packages/map-toolkit/src/deckgl/base-map/types.ts
@@ -14,9 +14,63 @@ import type { Payload } from '@accelint/bus';
 import type { UniqueId } from '@accelint/core';
 import type { PickingInfo } from '@deck.gl/core';
 import type { DeckglProps } from '@deckgl-fiber-renderer/types';
+import type { MapOptions } from 'maplibre-gl';
 import type { MjolnirGestureEvent, MjolnirPointerEvent } from 'mjolnir.js';
 import type { RbzOptions } from '@/maplibre/rbz-handler';
 import type { MapEvents } from './events';
+
+/**
+ * Keys on `MapOptions` that BaseMap manages internally and will silently strip
+ * from `mapLibreOptions`. These are either derived from BaseMap's camera/view
+ * state machine, locked to enforce Deck.gl picking and interaction guarantees,
+ * already exposed as a first-class BaseMap prop, or omitted by react-map-gl's
+ * underlying `MapInitOptions` type and therefore never reach MapLibre.
+ *
+ * Authoritative source: the array below is the single source of truth used
+ * both at runtime by `stripLockedMapLibreOptions` and at the type level via
+ * `LockedMapLibreOptionKey`. The `satisfies` clause guarantees every entry is
+ * a real `MapOptions` key.
+ */
+export const LOCKED_MAP_LIBRE_OPTION_KEYS = [
+  'container',
+  'style',
+  'center',
+  'bounds',
+  'fitBoundsOptions',
+  'zoom',
+  'pitch',
+  'bearing',
+  'projection',
+  'maxPitch',
+  'canvasContextAttributes',
+  'doubleClickZoom',
+  'dragRotate',
+  'pitchWithRotate',
+  'rollEnabled',
+  'boxZoom',
+] as const satisfies readonly (keyof MapOptions)[];
+
+/**
+ * Union of `MapOptions` keys that BaseMap manages internally and strips from
+ * `mapLibreOptions` before forwarding to MapLibre. Derived from
+ * {@link LOCKED_MAP_LIBRE_OPTION_KEYS} — see that constant's JSDoc for the
+ * rationale behind each locked key.
+ */
+export type LockedMapLibreOptionKey =
+  (typeof LOCKED_MAP_LIBRE_OPTION_KEYS)[number];
+
+/**
+ * Additional MapLibre `MapOptions` forwarded to the underlying map. Keys in
+ * `LockedMapLibreOptionKey` are stripped before being applied; everything
+ * else is spread onto the map instance.
+ *
+ * Defaults that BaseMap sets (e.g. `attributionControl: { compact: true }`)
+ * can be overridden by setting the corresponding key here.
+ */
+export type MapLibreOptions = Omit<
+  Partial<MapOptions>,
+  LockedMapLibreOptionKey
+>;
 
 /**
  * Props for the BaseMap component.
@@ -69,6 +123,34 @@ export type BaseMapProps = DeckglProps & {
    * options dynamically, change the map's `key` prop to force a remount.
    */
   rbzOptions?: RbzOptions;
+  /**
+   * Additional MapLibre `MapOptions` forwarded to the underlying map
+   * (e.g. `transformRequest`, `maxBounds`, `minZoom`, `maxZoom`, `locale`,
+   * `interactive`, `cooperativeGestures`). Keys BaseMap manages internally —
+   * camera/view state, controller-locked gestures (`doubleClickZoom`,
+   * `dragRotate`, `pitchWithRotate`, `rollEnabled`), the WebGL context, and
+   * keys already exposed as dedicated props (`boxZoom`, `styleUrl`) — are
+   * stripped before being applied.
+   *
+   * @example
+   * ```tsx
+   * <BaseMap
+   *   id={MAIN_MAP_ID}
+   *   styleUrl={MAPBOX_STYLE_URL}
+   *   mapLibreOptions={{
+   *     transformRequest: (url, resourceType) => {
+   *       if (url.startsWith('mapbox://')) {
+   *         return { url: url.replace('mapbox://', 'https://tiles.internal.example.com/') };
+   *       }
+   *       return { url };
+   *     },
+   *     maxBounds: [[-130, 20], [-60, 55]],
+   *     locale: { 'AttributionControl.ToggleAttribution': 'Toggle attribution' },
+   *   }}
+   * />
+   * ```
+   */
+  mapLibreOptions?: MapLibreOptions;
 };
 
 /**

--- a/packages/map-toolkit/src/deckgl/index.ts
+++ b/packages/map-toolkit/src/deckgl/index.ts
@@ -46,6 +46,7 @@ export type {
   MapEventType,
   MapHoverEvent,
   MapHoverPayload,
+  MapLibreOptions,
 } from './base-map/types';
 export type {
   CoffinCornerExtensionProps,

--- a/packages/map-toolkit/src/deckgl/symbol-layer/index.ts
+++ b/packages/map-toolkit/src/deckgl/symbol-layer/index.ts
@@ -106,7 +106,6 @@ const defaultProps: DefaultProps<SymbolLayerProps> = {
  * ```tsx
  * import '@accelint/map-toolkit/deckgl/symbol-layer/fiber';
  * import { BaseMap } from '@accelint/map-toolkit/deckgl';
- * import { View } from '@deckgl-fiber-renderer/dom';
  *
  * function MilitaryMap() {
  *   const units = [
@@ -116,7 +115,6 @@ const defaultProps: DefaultProps<SymbolLayerProps> = {
  *
  *   return (
  *     <BaseMap id="map" className="w-full h-full">
- *       <View id="main" controller />
  *       <symbolLayer
  *         id="military-units"
  *         data={units}

--- a/packages/map-toolkit/src/deckgl/text-layer/index.ts
+++ b/packages/map-toolkit/src/deckgl/text-layer/index.ts
@@ -76,7 +76,6 @@ export interface TextLayerProps<TData = unknown>
  * ```tsx
  * import '@accelint/map-toolkit/deckgl/text-layer/fiber';
  * import { BaseMap } from '@accelint/map-toolkit/deckgl';
- * import { View } from '@deckgl-fiber-renderer/dom';
  *
  * function MapWithLabels() {
  *   const cities = [
@@ -86,7 +85,6 @@ export interface TextLayerProps<TData = unknown>
  *
  *   return (
  *     <BaseMap id="map" className="w-full h-full">
- *       <View id="main" controller />
  *       <textLayer
  *         id="city-labels"
  *         data={cities}


### PR DESCRIPTION
Closes [#113](https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/113)

Maureen is working on pulling MapTK into Jeric2o and surfacing issues with the docs and lack of ability to change the basemap style. Exposing the maplibre options that don't conflict with ones set by other services seems like the right call for usability.

## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [ ] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

- `pnpm build && pnpm test && pnpm lint && pnpm format` pass
- preview map-toolkit and look at the BaseMap story
- confirm map renders, pan/zoom works, dark/light style toggle works
- (Optional) Locally pass the following into the story and verify: bounds clamp, no crash, drag-rotate stays disabled
```
<BaseMapComponent
  className='h-dvh w-dvw'
  id={BASE_MAP_STORY_ID}
  styleUrl={args.styleUrl}
  mapLibreOptions={{
    // Passthrough — should clamp the camera.
    maxBounds: [[-130, 20], [-60, 55]],
    // Locked — should be silently stripped (not crash).
    container: 'some-id',
    dragRotate: true,
  }}
/>
```

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [x] Ideation / brainstorming
- [x] Documentation
- [x] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
