### PR TITLE
Fix: Drawer Layout Issue

### DIFF
--- a/.changeset/fuzzy-boxes-draw.md
+++ b/.changeset/fuzzy-boxes-draw.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": minor
+---
+
+Fixed layout issue with drawer

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -29,7 +29,7 @@
     --drawer-main-rows: var(--drawer-main-row-start) /
       var(--drawer-main-row-end);
 
-    @apply relative grid h-full w-full;
+    @apply relative grid h-full w-full overflow-hidden;
     grid-template-columns: auto 1fr auto;
     grid-template-rows: auto 1fr auto;
 
@@ -233,12 +233,14 @@
     @apply gap-s p-l flex h-full min-h-0 flex-col;
     opacity: 0;
     pointer-events: none;
+    visibility: hidden;
 
     @variant motion-safe {
       transition:
         transform var(--animation-duration-fast)
           var(--animation-easing-standard),
-        opacity var(--animation-duration-fast) var(--animation-easing-standard);
+        opacity var(--animation-duration-fast) var(--animation-easing-standard),
+        visibility 0s var(--animation-duration-fast);
     }
 
     @variant group-placement-left/drawer {
@@ -260,7 +262,9 @@
     @variant group-open/drawer {
       opacity: 1;
       pointer-events: auto;
+      visibility: visible;
       transform: translate(0, 0);
+      transition-delay: 0s;
     }
 
     @variant group-placement-left/drawer {

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -75,11 +75,15 @@
       }
 
       @variant group-extend-right/layout {
-        @apply col-end-3;
+        @variant group-has-[[data-placement=right][data-open]]/layout {
+          @apply col-end-3;
+        }
       }
 
       @variant group-extend-left/layout {
-        @apply col-start-2;
+        @variant group-has-[[data-placement=left][data-open]]/layout {
+          @apply col-start-2;
+        }
       }
 
       @variant group-data-[extend=bottom]/layout {
@@ -96,11 +100,15 @@
       }
 
       @variant group-extend-top/layout {
-        @apply row-start-2;
+        @variant group-has-[[data-placement=top][data-open]]/layout {
+          @apply row-start-2;
+        }
       }
 
       @variant group-extend-bottom/layout {
-        @apply row-end-3;
+        @variant group-has-[[data-placement=bottom][data-open]]/layout {
+          @apply row-end-3;
+        }
       }
 
       @variant group-data-[extend=left]/layout {
@@ -117,11 +125,15 @@
       }
 
       @variant group-extend-right/layout {
-        @apply col-end-3;
+        @variant group-has-[[data-placement=right][data-open]]/layout {
+          @apply col-end-3;
+        }
       }
 
       @variant group-extend-left/layout {
-        @apply col-start-2;
+        @variant group-has-[[data-placement=left][data-open]]/layout {
+          @apply col-start-2;
+        }
       }
 
       @variant group-data-[extend=top]/layout {
@@ -138,11 +150,15 @@
       }
 
       @variant group-extend-top/layout {
-        @apply row-start-2;
+        @variant group-has-[[data-placement=top][data-open]]/layout {
+          @apply row-start-2;
+        }
       }
 
       @variant group-extend-bottom/layout {
-        @apply row-end-3;
+        @variant group-has-[[data-placement=bottom][data-open]]/layout {
+          @apply row-end-3;
+        }
       }
 
       @variant group-data-[extend=right]/layout {


### PR DESCRIPTION
Closes <!-- Github issue # here -->


#### Problem
There is a bug with `DrawerLayout` from the recent changes. Specifically, when user would collapse the bottom and/or right drawers, the drawer would collapse, but not "removed" from the view. It just transforms to their "hidden" position, but visually it is still present and breaks the intended layout. (Sorry, poor explanation. Best to check out the recording I have below to get a sense of what I meant)

The bug was likely introduced from a recent change for the drawer's animation.

#### Solution
We have updated the CSS so that it accounts for both `opacity` and `visibility` animations. We are defaulting the `.panel` `visibility` to `hidden`. Additionally, the `visibility` of the drawers are now animated to share the same duration as the delay set on `opacity` and `transform`, visually creating the drawer opening/closing animation.


## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->

1. Review current deployed storybook by navigating to `DrawerLayout`
2. You should see the bottom and right drawers, upon collapse, bleeds out of the viewport and takes up some space on the screen. This is a bug where the drawer is supposed to be "hidden" on collapse, with no additional spaces in the viewport allocated for the drawer
3. Pull this branch and run storybook
4. Navigate to `DrawerLayout`
5. Open/close the drawers. It should now work as expected with NO layout shifts and animations are visually matching the behavior


## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [x] Implementation

Before:

https://github.com/user-attachments/assets/26ab66aa-2fec-4337-ad95-4b59a4a60247

After:


https://github.com/user-attachments/assets/485aa3f4-612f-4d08-9c3d-8d5dff7d8ff4


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
