### PR TITLE
fix: set projection after MapLibre styles load

### DIFF
--- a/.changeset/fix-basemap-globe-style-not-loading.md
+++ b/.changeset/fix-basemap-globe-style-not-loading.md
@@ -1,0 +1,5 @@
+---
+'@accelint/map-toolkit': patch
+---
+
+Fix `BaseMap` runtime error "Style is not done loading." when `defaultView='3D'` (globe projection). Projection is now applied via `setProjection` after MapLibre's style has loaded, instead of being passed as the initial `projection` prop to `react-map-gl/maplibre`.

--- a/packages/map-toolkit/src/deckgl/base-map/index.test.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.test.tsx
@@ -11,31 +11,110 @@
  */
 
 import { uuid } from '@accelint/core';
-import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { BaseMap, stripLockedMapLibreOptions } from './index';
 import { LOCKED_MAP_LIBRE_OPTION_KEYS } from './types';
 import type { MapOptions } from 'maplibre-gl';
 import type { MapLibreOptions } from './types';
 
-// Mock MapLibre hook since it requires browser APIs
-vi.mock('../../maplibre/hooks/use-maplibre', () => ({
-  useMapLibre: vi.fn(),
+interface FakeMap {
+  setProjection: Mock;
+  isStyleLoaded: Mock;
+}
+
+function createFakeMap(): FakeMap {
+  return {
+    setProjection: vi.fn(),
+    isStyleLoaded: vi.fn().mockReturnValue(false),
+  };
+}
+
+let activeMap: FakeMap | null = null;
+let capturedOnLoad: (() => void) | undefined;
+
+function useFakeMap(map: FakeMap): void {
+  activeMap = map;
+}
+
+function fireMapLoad(): void {
+  capturedOnLoad?.();
+}
+
+// Mock react-map-gl/maplibre so tests can drive the MapLibre lifecycle
+// (ref population + onLoad event) without a real WebGL context.
+vi.mock('react-map-gl/maplibre', () => ({
+  Map: ({
+    children,
+    onLoad,
+    ref,
+  }: {
+    children?: React.ReactNode;
+    onLoad?: () => void;
+    ref?: { current: unknown };
+  }) => {
+    if (ref && typeof ref === 'object') {
+      ref.current = { getMap: () => activeMap };
+    }
+    capturedOnLoad = onLoad;
+
+    return <div data-testid='maplibre-mock'>{children}</div>;
+  },
+  useControl: vi.fn(),
 }));
+
+beforeEach(() => {
+  activeMap = null;
+  capturedOnLoad = undefined;
+});
 
 describe('BaseMap', () => {
   it('should render without crashing when given a valid id', () => {
-    const { container } = render(<BaseMap id={uuid()} />);
+    useFakeMap(createFakeMap());
 
-    expect(container.firstChild).toBeInTheDocument();
+    render(<BaseMap id={uuid()} />);
+
+    expect(screen.getByTestId('maplibre-mock')).toBeInTheDocument();
   });
 
-  it('should apply className to the root element', () => {
-    const { container } = render(
-      <BaseMap className='custom-map-class' id={uuid()} />,
-    );
+  it('should apply className to the wrapping element', () => {
+    useFakeMap(createFakeMap());
 
-    expect(container.firstChild).toHaveClass('custom-map-class');
+    render(<BaseMap className='custom-map-class' id={uuid()} />);
+
+    const map = screen.getByTestId('maplibre-mock');
+
+    expect(map.closest('.custom-map-class')).not.toBeNull();
+  });
+
+  it('should apply globe projection after MapLibre style loads when defaultView is 3D', () => {
+    const fakeMap = createFakeMap();
+    useFakeMap(fakeMap);
+
+    render(<BaseMap id={uuid()} defaultView='3D' />);
+
+    expect(fakeMap.setProjection).not.toHaveBeenCalled();
+
+    act(() => {
+      fakeMap.isStyleLoaded.mockReturnValue(true);
+      fireMapLoad();
+    });
+
+    expect(fakeMap.setProjection).toHaveBeenCalledWith({ type: 'globe' });
+  });
+
+  it('should apply mercator projection after MapLibre style loads when defaultView is 2D', () => {
+    const fakeMap = createFakeMap();
+    useFakeMap(fakeMap);
+
+    render(<BaseMap id={uuid()} defaultView='2D' />);
+
+    act(() => {
+      fakeMap.isStyleLoaded.mockReturnValue(true);
+      fireMapLoad();
+    });
+
+    expect(fakeMap.setProjection).toHaveBeenCalledWith({ type: 'mercator' });
   });
 });
 

--- a/packages/map-toolkit/src/deckgl/base-map/index.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.tsx
@@ -16,7 +16,7 @@ import { useEffectEvent, useEmit } from '@accelint/bus/react';
 import { Deckgl, useDeckgl } from '@deckgl-fiber-renderer/dom';
 import type { PickingInfo, ViewStateChangeParameters } from '@deck.gl/core';
 import 'client-only';
-import { useCallback, useId, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
 import {
   Map as MapLibre,
   type MapRef,
@@ -324,20 +324,26 @@ export function BaseMap({
       dragRotate: false,
       pitchWithRotate: false,
       rollEnabled: false,
-      projection: cameraState.projection,
       maxPitch: cameraState.view === '2D' ? 0 : 85,
       canvasContextAttributes: CANVAS_CONTEXT_ATTRIBUTES,
       boxZoom,
     }),
-    [
-      viewState,
-      container,
-      cameraState.projection,
-      cameraState.view,
-      boxZoom,
-      filteredMapLibreOptions,
-    ],
+    [viewState, container, cameraState.view, boxZoom, filteredMapLibreOptions],
   );
+
+  // Sync `cameraState.projection` to subsequent map state. The initial value
+  // is applied from `handleMapLoad` (MapLibre's `onLoad`) — by then the style
+  // has loaded and `setProjection` is safe. We don't pass `projection` as a
+  // prop to `<MapLibre>` because react-map-gl applies it via `setProjection`
+  // before `style.load`, which MapLibre rejects with "Style is not done
+  // loading."
+  useEffect(() => {
+    const map = mapRef.current?.getMap();
+    if (!map?.isStyleLoaded()) {
+      return;
+    }
+    map.setProjection({ type: cameraState.projection });
+  }, [cameraState.projection]);
 
   const emitClick = useEmit<MapClickEvent>(MapEvents.click);
   const emitHover = useEmit<MapHoverEvent>(MapEvents.hover);
@@ -444,6 +450,12 @@ export function BaseMap({
     }, 200);
   });
 
+  // Fired by react-map-gl when MapLibre's `load` event fires (after
+  // `style.load`). This is the first point at which `setProjection` is safe.
+  const handleMapLoad = useEffectEvent(() => {
+    mapRef.current?.getMap().setProjection({ type: cameraState.projection });
+  });
+
   const handleLoad = useEffectEvent(() => {
     //--- force update viewport state once all viewports initialized ---
     // @ts-expect-error squirrelly deckglInstance typing
@@ -498,6 +510,7 @@ export function BaseMap({
           onMove={(evt) => {
             setCameraState(evt.viewState);
           }}
+          onLoad={handleMapLoad}
           mapStyle={styleUrl}
           ref={mapRef}
           {...mapOptions}

--- a/packages/map-toolkit/src/deckgl/base-map/index.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.tsx
@@ -311,10 +311,12 @@ export function BaseMap({
 
   // Spread order: default → consumer overrides → locked keys (last wins).
   //
-  // Don't add MapLibre options here whose setter requires `isStyleLoaded()`
-  // (e.g. setProjection, setLight, setTerrain, setSky). react-map-gl applies
-  // prop diffs before `style.load`, which those setters reject. Sync them via
-  // the post-load pattern used for `projection` below.
+  // Don't add `projection` here. react-map-gl's `_updateSettings` iterates
+  // its `settingNames` list (which includes `projection`) on every `setProps`
+  // call and invokes each setter unconditionally - bypassing the style-load
+  // guard on its `_updateStyleComponents` path. maplibre's `setProjection`
+  // then throws "Style is not done loading." Sync via the post-load pattern
+  // below - same approach as `useMapLibre` uses for the same setter.
   const mapOptions = useMemo(
     () => ({
       attributionControl: DEFAULT_ATTRIBUTION_CONTROL,

--- a/packages/map-toolkit/src/deckgl/base-map/index.tsx
+++ b/packages/map-toolkit/src/deckgl/base-map/index.tsx
@@ -310,6 +310,11 @@ export function BaseMap({
   );
 
   // Spread order: default → consumer overrides → locked keys (last wins).
+  //
+  // Don't add MapLibre options here whose setter requires `isStyleLoaded()`
+  // (e.g. setProjection, setLight, setTerrain, setSky). react-map-gl applies
+  // prop diffs before `style.load`, which those setters reject. Sync them via
+  // the post-load pattern used for `projection` below.
   const mapOptions = useMemo(
     () => ({
       attributionControl: DEFAULT_ATTRIBUTION_CONTROL,
@@ -331,17 +336,15 @@ export function BaseMap({
     [viewState, container, cameraState.view, boxZoom, filteredMapLibreOptions],
   );
 
-  // Sync `cameraState.projection` to subsequent map state. The initial value
-  // is applied from `handleMapLoad` (MapLibre's `onLoad`) — by then the style
-  // has loaded and `setProjection` is safe. We don't pass `projection` as a
-  // prop to `<MapLibre>` because react-map-gl applies it via `setProjection`
-  // before `style.load`, which MapLibre rejects with "Style is not done
-  // loading."
+  // `setProjection` throws if called before the style is loaded. Initial
+  // application happens in `handleMapLoad`; this effect syncs later changes.
   useEffect(() => {
     const map = mapRef.current?.getMap();
+
     if (!map?.isStyleLoaded()) {
       return;
     }
+
     map.setProjection({ type: cameraState.projection });
   }, [cameraState.projection]);
 
@@ -450,8 +453,7 @@ export function BaseMap({
     }, 200);
   });
 
-  // Fired by react-map-gl when MapLibre's `load` event fires (after
-  // `style.load`). This is the first point at which `setProjection` is safe.
+  // First point at which `setProjection` is safe (after `style.load`).
   const handleMapLoad = useEffectEvent(() => {
     mapRef.current?.getMap().setProjection({ type: cameraState.projection });
   });


### PR DESCRIPTION
Closes https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/114

Maureen noticed an issue that arose after the PR to expose mapLibreOptions where, when setting the defaultView to 3D on the BaseMap, MapLibre would error with the following: 

<img width="1636" height="1024" alt="image" src="https://github.com/user-attachments/assets/85b79f19-1a96-40e2-8776-5c018949f852" />

This PR waits to set projection until after the style has been loaded to avoid the error.


## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions
- to see the initial error, on `main` go to the next app BaseMap and set the `defaultView` to `3D`: 
<img width="1397" height="691" alt="Screenshot 2026-05-20 at 11 25 49 AM" src="https://github.com/user-attachments/assets/302162a8-241f-4639-bd30-309a6e7e11ec" />
 
-  notice the error on the Map page: 
<img width="2141" height="525" alt="Screenshot 2026-05-20 at 11 23 58 AM" src="https://github.com/user-attachments/assets/fd679a49-13cf-4dbb-ab1e-1fe53d0ae1c9" />

- switch to this branch and rebuild to get the changes in map-toolkit
- run the next app and notice you are in globe view without the error: 

<img width="2141" height="1251" alt="Screenshot 2026-05-20 at 11 25 27 AM" src="https://github.com/user-attachments/assets/317fd757-a107-4260-afb6-de60f65d6535" />


## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [x] Ideation / brainstorming
- [x] Documentation
- [x] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
