### PR TITLE
feat: add override icon to Notice

### DIFF
--- a/.changeset/few-corners-change.md
+++ b/.changeset/few-corners-change.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": minor
+---
+
+Adds ability to override Notice component icon

--- a/packages/design-toolkit/src/components/notice/index.tsx
+++ b/packages/design-toolkit/src/components/notice/index.tsx
@@ -73,6 +73,7 @@ export function Notice({
   primary,
   secondary,
   hideIcon,
+  iconOverride,
   showClose,
   shouldCloseOnAction,
   size = 'medium',
@@ -80,6 +81,9 @@ export function Notice({
   onSecondaryAction,
   onClose,
 }: NoticeProps) {
+  const showOverrideIcon = iconOverride && size === 'medium';
+  const showIcon = !hideIcon && size === 'medium' && !iconOverride;
+
   return (
     <Toast
       className={clsx('group/notice', styles.notice, classNames?.notice)}
@@ -89,9 +93,12 @@ export function Notice({
       style={{ viewTransitionName: id }}
     >
       <ToastContent className={clsx(styles.content, classNames?.content)}>
-        {!hideIcon && size === 'medium' && (
-          <NoticeIcon color={color} size={size} />
+        {showOverrideIcon && (
+          <Icon color={color} size='medium'>
+            {iconOverride}
+          </Icon>
         )}
+        {showIcon && <NoticeIcon color={color} size={size} />}
         <Text
           slot='description'
           className={clsx(styles.message, classNames?.message)}

--- a/packages/design-toolkit/src/components/notice/notice.docs.mdx
+++ b/packages/design-toolkit/src/components/notice/notice.docs.mdx
@@ -46,6 +46,20 @@ A notification component for displaying temporary messages, alerts, and user fee
 />
 ```
 
+## With Custom Icon
+
+<Canvas of={NoticeStories.Custom} />
+
+```tsx
+import { Check } from '@accelint/icons';
+
+<Notice
+  id="7a3b6dfd-6596-472c-af1a-06d433958705"
+  message="This is a custom notice message"
+  iconOverride={<Check />}
+/>
+```
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -57,6 +71,7 @@ A notification component for displaying temporary messages, alerts, and user fee
 | `primary` | `ButtonProps` | - | Primary action button config |
 | `secondary` | `ButtonProps` | - | Secondary action button config |
 | `hideIcon` | `boolean` | `false` | Whether to hide the icon |
+| `iconOverride` | `icon` | `undefined` | Icon to override default icons |
 | `showClose` | `boolean` | `false` | Whether to show close button |
 | `shouldCloseOnAction` | `boolean` | `false` | Close on action press |
 | `onPrimaryAction` | `() => void` | - | Primary button callback |

--- a/packages/design-toolkit/src/components/notice/notice.stories.tsx
+++ b/packages/design-toolkit/src/components/notice/notice.stories.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { Check } from '@accelint/icons';
 import { Notice } from './';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -34,6 +35,10 @@ const meta: Meta<typeof Notice> = {
 export default meta;
 
 export const Default: StoryObj<typeof Notice> = {};
+
+export const Custom: StoryObj<typeof Notice> = {
+  render: (args) => <Notice {...args} iconOverride={<Check />} />,
+};
 
 export const ButtonEvents: StoryObj<typeof Notice> = {
   render: (args) => (

--- a/packages/design-toolkit/src/components/notice/types.ts
+++ b/packages/design-toolkit/src/components/notice/types.ts
@@ -13,6 +13,7 @@
 
 import type { Payload, StructuredCloneableData } from '@accelint/bus';
 import type { UniqueId } from '@accelint/core';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 import type { ToastListProps } from 'react-aria-components/Toast';
 import type { ButtonProps } from '../button/types';
 import type { NoticeEventTypes } from './events';
@@ -126,6 +127,8 @@ export type NoticeProps = Omit<
   };
   /** Whether to hide the status icon. */
   hideIcon?: boolean;
+  /** Override the default icon */
+  iconOverride?: ReactNode;
   /** Whether to show the close button. */
   showClose?: boolean;
   /** Whether to close the notice when an action button is pressed. */


### PR DESCRIPTION
Closes n/a
see: `CORE-177`

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

Allows passing a custom icon into the `<Notice overrideIcon={<MyIcon />} />`

The automatic color-based switching is useful for basic notices, but shouldn't disallow customization for client apps.

## ❓ Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
