### PR TITLE
fix: clear button focus blocking and add docs

### DIFF
--- a/.changeset/huge-forks-buy.md
+++ b/.changeset/huge-forks-buy.md
@@ -2,4 +2,4 @@
 "@accelint/design-toolkit": patch
 ---
 
-Fixes ComboboxField bug where invisible clear button prevented input focus
+Fix ComboBoxField clear button: clicking where the hidden clear button sits now focuses the input and opens the dropdown instead of doing nothing.

--- a/.changeset/huge-forks-buy.md
+++ b/.changeset/huge-forks-buy.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fixes ComboboxField bug where invisible clear button prevented input focus

--- a/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
+++ b/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
@@ -18,8 +18,8 @@ Uses the [Options](?path=/docs/components-options--playground) component system 
 ```tsx
 <ComboBoxField defaultItems={items} label="Select animal">
   {(item) => (
-    <OptionsItem 
-      key={item.id} 
+    <OptionsItem
+      key={item.id}
       textValue={item.name}  // Required for filtering to work
     >
       <Icon>{item.prefixIcon}</Icon>
@@ -78,21 +78,6 @@ Uses the [Options](?path=/docs/components-options--playground) component system 
 </ComboBoxField>
 ```
 <Canvas of={ComboBoxStories.Readonly} />
-
-### Multiple Selection with Chips
-```tsx
-<ComboBoxField selectionMode="multiple" defaultItems={items} onChange={handleChange}>
-  {(item) => (
-    <OptionsItem key={item.id} textValue={item.name}>
-      <OptionsItemLabel>{item.name}</OptionsItemLabel>
-    </OptionsItem>
-  )}
-</ComboBoxField>
-```
-
-When `selectionMode="multiple"` is set, users can select multiple items from the dropdown. Display selected items as deletable chips using `ChipList` and `DeletableChip` components. Handle the `onChange` callback to track selections, and use `ChipList`'s `onRemove` to allow users to remove individual selections.
-
-<Canvas of={ComboBoxStories.MultipleSelection} />
 
 ## Sizes
 
@@ -292,7 +277,7 @@ const items = [
    <div style={{ overflow: 'hidden' }}>
      <ComboBoxField defaultItems={items}>...</ComboBoxField>
    </div>
-   
+
    // ✅ Allow overflow or use portal
    <div style={{ overflow: 'visible' }}>
      <ComboBoxField defaultItems={items}>...</ComboBoxField>
@@ -305,7 +290,7 @@ const items = [
    ```tsx
    // ❌ Won't open on focus/click
    <ComboBoxField menuTrigger="manual" defaultItems={items}>...</ComboBoxField>
-   
+
    // ✅ Opens on focus (default)
    <ComboBoxField defaultItems={items}>...</ComboBoxField>
    // or explicitly:
@@ -333,7 +318,7 @@ const items = [
 <ComboBoxField inputValue={value} />
 
 // ✅ Controlled with handler
-<ComboBoxField 
+<ComboBoxField
   inputValue={value}
   onInputChange={setValue}
 />

--- a/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
+++ b/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
@@ -255,22 +255,9 @@ const items = [
 
 **Common causes:**
 
-1. **Parent has `overflow: hidden`** - The dropdown (popover) uses absolute positioning and gets clipped.
-   ```tsx
-   // ❌ Dropdown gets clipped
-   <div style={{ overflow: 'hidden' }}>
-     <ComboBoxField defaultItems={items}>...</ComboBoxField>
-   </div>
+1. **Z-index stacking context issue** - Another element is covering the dropdown. Check if parent elements have `z-index` that creates a stacking context.
 
-   // ✅ Allow overflow or use portal
-   <div style={{ overflow: 'visible' }}>
-     <ComboBoxField defaultItems={items}>...</ComboBoxField>
-   </div>
-   ```
-
-2. **Z-index stacking context issue** - Another element is covering the dropdown. Check if parent elements have `z-index` that creates a stacking context.
-
-3. **menuTrigger set to "manual"** - The dropdown won't open automatically.
+2. **menuTrigger set to "manual"** - The dropdown won't open automatically.
    ```tsx
    // ❌ Won't open on focus/click
    <ComboBoxField menuTrigger="manual" defaultItems={items}>...</ComboBoxField>
@@ -281,7 +268,7 @@ const items = [
    <ComboBoxField menuTrigger="focus" defaultItems={items}>...</ComboBoxField>
    ```
 
-4. **No items to show** - If `defaultItems` is empty or all items are filtered out, the dropdown may not open.
+3. **No items to show** - If `defaultItems` is empty or all items are filtered out, the dropdown may not open.
 
 ### Nothing renders
 **Problem:** The dropdown is empty or items don't appear.

--- a/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
+++ b/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
@@ -18,7 +18,10 @@ Uses the [Options](?path=/docs/components-options--playground) component system 
 ```tsx
 <ComboBoxField defaultItems={items} label="Select animal">
   {(item) => (
-    <OptionsItem key={item.id} textValue={item.name}>
+    <OptionsItem 
+      key={item.id} 
+      textValue={item.name}  // Required for filtering to work
+    >
       <Icon>{item.prefixIcon}</Icon>
       <OptionsItemContent>
         <OptionsItemLabel>{item.name}</OptionsItemLabel>
@@ -29,6 +32,8 @@ Uses the [Options](?path=/docs/components-options--playground) component system 
 </ComboBoxField>
 ```
 <Canvas of={ComboBoxStories.Default} />
+
+> **Important:** Always include `textValue` on each `OptionsItem` when using `defaultItems`. This enables React Aria's built-in filtering.
 
 ### With Sections
 ```tsx
@@ -73,6 +78,21 @@ Uses the [Options](?path=/docs/components-options--playground) component system 
 </ComboBoxField>
 ```
 <Canvas of={ComboBoxStories.Readonly} />
+
+### Multiple Selection with Chips
+```tsx
+<ComboBoxField selectionMode="multiple" defaultItems={items} onChange={handleChange}>
+  {(item) => (
+    <OptionsItem key={item.id} textValue={item.name}>
+      <OptionsItemLabel>{item.name}</OptionsItemLabel>
+    </OptionsItem>
+  )}
+</ComboBoxField>
+```
+
+When `selectionMode="multiple"` is set, users can select multiple items from the dropdown. Display selected items as deletable chips using `ChipList` and `DeletableChip` components. Handle the `onChange` callback to track selections, and use `ChipList`'s `onRemove` to allow users to remove individual selections.
+
+<Canvas of={ComboBoxStories.MultipleSelection} />
 
 ## Sizes
 
@@ -136,18 +156,204 @@ Context provider for setting default props across multiple ComboBoxField compone
 </ComboBoxFieldProvider>
 ```
 
+## Usage Patterns
+
+ComboBoxField supports two distinct patterns for rendering items:
+
+### Dynamic Items (Recommended)
+Use `defaultItems` or `items` with a render function. React Aria handles filtering automatically.
+
+```tsx
+// ✅ Filtering works automatically
+<ComboBoxField defaultItems={items}>
+  {(item) => (
+    <OptionsItem key={item.id} textValue={item.name}>
+      <OptionsItemLabel>{item.name}</OptionsItemLabel>
+    </OptionsItem>
+  )}
+</ComboBoxField>
+```
+
+**Key requirements:**
+- Each item must have an `id` field
+- Each `OptionsItem` must have a `textValue` prop for filtering to work
+- Don't forget the React `key` prop in your render function
+
+### Static Items
+Render `OptionsItem` children directly. You must handle filtering manually.
+
+```tsx
+// ⚠️ No automatic filtering - you control the children
+<ComboBoxField>
+  <OptionsItem textValue="Cat">Cat</OptionsItem>
+  <OptionsItem textValue="Dog">Dog</OptionsItem>
+  <OptionsItem textValue="Bird">Bird</OptionsItem>
+</ComboBoxField>
+```
+
+## Common Issues
+
+### Filtering doesn't work
+**Problem:** You type in the combobox but items don't filter.
+
+**Solution:** Add the `textValue` prop to each `OptionsItem`. This tells React Aria what text to match against.
+
+```tsx
+// ❌ Filtering broken - no textValue
+<OptionsItem key={item.id}>
+  {item.name}
+</OptionsItem>
+
+// ✅ Filtering works
+<OptionsItem key={item.id} textValue={item.name}>
+  {item.name}
+</OptionsItem>
+```
+
+### TypeScript errors about item type
+**Problem:** TypeScript complains your items don't match `OptionsDataItem`.
+
+**Solution:** `OptionsDataItem` is just a suggested base type. Your items only need an `id` field. The `name` field is optional - use whatever fields you need.
+
+```tsx
+// Your custom item type
+interface Animal {
+  id: number;
+  species: string;  // Not "name" - that's fine!
+  habitat?: string;
+}
+
+// Works perfectly
+<ComboBoxField<Animal> defaultItems={animals}>
+  {(item) => (
+    <OptionsItem key={item.id} textValue={item.species}>
+      <OptionsItemLabel>{item.species}</OptionsItemLabel>
+      {item.habitat && (
+        <OptionsItemDescription>{item.habitat}</OptionsItemDescription>
+      )}
+    </OptionsItem>
+  )}
+</ComboBoxField>
+```
+
+### React key warnings
+**Problem:** Console shows "Each child in a list should have a unique key prop".
+
+**Solution:** Add `key={item.id}` to your `OptionsItem` in the render function.
+
+```tsx
+// ❌ Missing key
+<ComboBoxField defaultItems={items}>
+  {(item) => <OptionsItem textValue={item.name}>...</OptionsItem>}
+</ComboBoxField>
+
+// ✅ With key
+<ComboBoxField defaultItems={items}>
+  {(item) => <OptionsItem key={item.id} textValue={item.name}>...</OptionsItem>}
+</ComboBoxField>
+```
+
+### Selection or keyboard navigation broken
+**Problem:** Selecting items behaves strangely, or keyboard navigation jumps unexpectedly.
+
+**Solution:** All item `id` values must be unique across the entire list. React Aria uses these IDs for selection and focus management.
+
+```tsx
+// ❌ Duplicate IDs cause unpredictable behavior
+const items = [
+  { id: 1, name: 'Cat' },
+  { id: 1, name: 'Dog' },  // Duplicate ID!
+  { id: 2, name: 'Bird' },
+];
+
+// ✅ All IDs are unique
+const items = [
+  { id: 1, name: 'Cat' },
+  { id: 2, name: 'Dog' },
+  { id: 3, name: 'Bird' },
+];
+
+// ✅ String IDs work too
+const items = [
+  { id: 'cat', name: 'Cat' },
+  { id: 'dog', name: 'Dog' },
+  { id: 'bird', name: 'Bird' },
+];
+```
+
+### Dropdown doesn't show at all
+**Problem:** Clicking or focusing the field doesn't open the dropdown.
+
+**Common causes:**
+
+1. **Parent has `overflow: hidden`** - The dropdown (popover) uses absolute positioning and gets clipped.
+   ```tsx
+   // ❌ Dropdown gets clipped
+   <div style={{ overflow: 'hidden' }}>
+     <ComboBoxField defaultItems={items}>...</ComboBoxField>
+   </div>
+   
+   // ✅ Allow overflow or use portal
+   <div style={{ overflow: 'visible' }}>
+     <ComboBoxField defaultItems={items}>...</ComboBoxField>
+   </div>
+   ```
+
+2. **Z-index stacking context issue** - Another element is covering the dropdown. Check if parent elements have `z-index` that creates a stacking context.
+
+3. **menuTrigger set to "manual"** - The dropdown won't open automatically.
+   ```tsx
+   // ❌ Won't open on focus/click
+   <ComboBoxField menuTrigger="manual" defaultItems={items}>...</ComboBoxField>
+   
+   // ✅ Opens on focus (default)
+   <ComboBoxField defaultItems={items}>...</ComboBoxField>
+   // or explicitly:
+   <ComboBoxField menuTrigger="focus" defaultItems={items}>...</ComboBoxField>
+   ```
+
+4. **No items to show** - If `defaultItems` is empty or all items are filtered out, the dropdown may not open.
+
+### Nothing renders
+**Problem:** The dropdown is empty or items don't appear.
+
+**Checklist:**
+- Using `defaultItems`? Make sure each item has an `id` field
+- Using static children? Make sure they're direct `OptionsItem` or `OptionsSection` elements
+- Check browser console for React/TypeScript errors
+- Verify your items array isn't empty
+
+### Controlled value not updating
+**Problem:** You're setting `inputValue` but it doesn't change.
+
+**Solution:** When using controlled mode, you must handle `onInputChange` and update your state.
+
+```tsx
+// ❌ Controlled but no handler - input appears frozen
+<ComboBoxField inputValue={value} />
+
+// ✅ Controlled with handler
+<ComboBoxField 
+  inputValue={value}
+  onInputChange={setValue}
+/>
+
+// ✅ Or use uncontrolled mode
+<ComboBoxField defaultInputValue={initialValue} />
+```
+
 ## Accessibility
 - Keyboard: Arrow keys to navigate, Enter to select, Escape to close
 - Type-ahead filtering as you type
 - ARIA attributes for screen readers
 - Focus management between input and dropdown
-- Clear button excluded from tab order for streamlined keyboard navigatio
-- Focus management between input and dropdown
+- Clear button excluded from tab order for streamlined keyboard navigation
 
 ## Implementation Notes
 - Wraps `ComboBox` from react-aria-components with `Virtualizer` for large lists
 - Uses the [Options](?path=/docs/components-options--playground) component system for dropdown content
 - Supports both static children and dynamic `defaultItems`/`items` rendering
+- React Aria handles filtering automatically when using `defaultItems` - matches input against each item's `textValue`
 
 **Related:**
 - [React Aria ComboBox](https://react-spectrum.adobe.com/react-aria/ComboBox.html)

--- a/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
+++ b/packages/design-toolkit/src/components/combobox-field/combobox-field.docs.mdx
@@ -143,10 +143,10 @@ Context provider for setting default props across multiple ComboBoxField compone
 
 ## Usage Patterns
 
-ComboBoxField supports two distinct patterns for rendering items:
+You can provide items two ways, and React Aria's filtering behavior depends on whether the collection is uncontrolled or controlled.
 
-### Dynamic Items (Recommended)
-Use `defaultItems` or `items` with a render function. React Aria handles filtering automatically.
+Dynamic items (recommended)
+Pass `defaultItems` with a render function. React Aria filters the list automatically as the user types.
 
 ```tsx
 // ✅ Filtering works automatically
@@ -161,11 +161,12 @@ Use `defaultItems` or `items` with a render function. React Aria handles filteri
 
 **Key requirements:**
 - Each item must have an `id` field
-- Each `OptionsItem` must have a `textValue` prop for filtering to work
+- Each `OptionsItem` must have a `textValue` prop so React Aria knows what text to match against
 - Don't forget the React `key` prop in your render function
 
 ### Static Items
-Render `OptionsItem` children directly. You must handle filtering manually.
+### Static items
+Render `OptionsItem` children directly. React Aria still filters these automatically by each item's `textValue`.
 
 ```tsx
 // ⚠️ No automatic filtering - you control the children
@@ -175,6 +176,9 @@ Render `OptionsItem` children directly. You must handle filtering manually.
   <OptionsItem textValue="Bird">Bird</OptionsItem>
 </ComboBoxField>
 ```
+
+### Controlled filtering
+Use the `items` prop (instead of `defaultItems`) when you want to filter the list yourself, for example async search or custom match logic. React Aria renders exactly the items you pass and does **not** filter them, so update the list from `onInputChange`.
 
 ## Common Issues
 
@@ -196,30 +200,10 @@ Render `OptionsItem` children directly. You must handle filtering manually.
 ```
 
 ### TypeScript errors about item type
-**Problem:** TypeScript complains your items don't match `OptionsDataItem`.
+**Problem:** TypeScript complains your items don't satisfy the `ComboBoxField<T>` constraint.
 
-**Solution:** `OptionsDataItem` is just a suggested base type. Your items only need an `id` field. The `name` field is optional - use whatever fields you need.
+**Solution:** `ComboBoxField<T extends OptionsDataItem>` requires every item to have an `id` (`string | number`) and a `name` (`string`). Add any other fields you need on top of those.
 
-```tsx
-// Your custom item type
-interface Animal {
-  id: number;
-  species: string;  // Not "name" - that's fine!
-  habitat?: string;
-}
-
-// Works perfectly
-<ComboBoxField<Animal> defaultItems={animals}>
-  {(item) => (
-    <OptionsItem key={item.id} textValue={item.species}>
-      <OptionsItemLabel>{item.species}</OptionsItemLabel>
-      {item.habitat && (
-        <OptionsItemDescription>{item.habitat}</OptionsItemDescription>
-      )}
-    </OptionsItem>
-  )}
-</ComboBoxField>
-```
 
 ### React key warnings
 **Problem:** Console shows "Each child in a list should have a unique key prop".
@@ -338,7 +322,7 @@ const items = [
 - Wraps `ComboBox` from react-aria-components with `Virtualizer` for large lists
 - Uses the [Options](?path=/docs/components-options--playground) component system for dropdown content
 - Supports both static children and dynamic `defaultItems`/`items` rendering
-- React Aria handles filtering automatically when using `defaultItems` - matches input against each item's `textValue`
+- React Aria filters uncontrolled collections (`defaultItems` or static children) automatically against each item's `textValue`; pass the `items` prop to filter the list yourself
 
 **Related:**
 - [React Aria ComboBox](https://react-spectrum.adobe.com/react-aria/ComboBox.html)

--- a/packages/design-toolkit/src/components/combobox-field/styles.module.css
+++ b/packages/design-toolkit/src/components/combobox-field/styles.module.css
@@ -18,7 +18,7 @@
   }
 
   .control {
-    @apply rounded-medium px-s py-xs fg-primary-bold outline-interactive gap-xs relative flex items-center outline;
+    @apply rounded-medium px-s py-xs fg-primary-bold outline-interactive gap-xs flex items-center outline;
 
     @variant placeholder {
       @apply fg-primary-muted;
@@ -118,12 +118,20 @@
 
 @layer components.l2 {
   .clear {
-    @apply absolute hidden;
-    right: var(--icon-size-l);
+    @apply pointer-events-none invisible;
 
     @variant group-focus-within/combobox-field {
       @variant group-not-data-empty/combobox-field {
-        @apply flex;
+        @apply pointer-events-auto visible;
+      }
+    }
+  }
+
+  .input {
+    @variant group-not-focus-within/combobox-field {
+      @variant group-data-empty/combobox-field {
+        margin-right: calc((var(--icon-size-s) + var(--spacing-xs)) * -1);
+        padding-right: calc(var(--icon-size-s) + var(--spacing-xs));
       }
     }
   }

--- a/packages/design-toolkit/src/components/combobox-field/styles.module.css
+++ b/packages/design-toolkit/src/components/combobox-field/styles.module.css
@@ -18,7 +18,7 @@
   }
 
   .control {
-    @apply rounded-medium px-s py-xs fg-primary-bold outline-interactive gap-xs flex items-center outline;
+    @apply rounded-medium px-s py-xs fg-primary-bold outline-interactive gap-xs relative flex items-center outline;
 
     @variant placeholder {
       @apply fg-primary-muted;
@@ -118,11 +118,12 @@
 
 @layer components.l2 {
   .clear {
-    @apply invisible;
+    @apply absolute hidden;
+    right: var(--icon-size-l);
 
     @variant group-focus-within/combobox-field {
       @variant group-not-data-empty/combobox-field {
-        @apply visible;
+        @apply flex;
       }
     }
   }


### PR DESCRIPTION
Closes [Issue 117](https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/117)

This PR fixes a problem where, when `isClearable` is enabled, there is a spot in the ComboboxField input where clicking does not focus the input, which means the dropdown does not open. This creates a confusing UX experience for the user where they are trying to focus the Combobox and make a selection, but it appears broken because of the "invisible" clear button. The chevron and other areas of the input are still functional.

<img width="364" height="168" alt="CleanShot 2026-05-26 at 10 33 57" src="https://github.com/user-attachments/assets/989b8431-e584-4a0c-8148-01b357199c64" />

<img width="330" height="310" alt="CleanShot 2026-05-26 at 10 37 17" src="https://github.com/user-attachments/assets/5a12e4e4-a4de-4b7d-81c3-9a463e073a0b" />

Additionally, some documentation is added to make usage of the component clearer.


## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

Make sure that the entire input is focusable and no regressions are introduced to the clear behavior.

with bug: https://design-toolkit.accelint.io/?path=/story/components-comboboxfield--default
without bug: https://design-toolkit-git-feat-combobox-updates-accelint.vercel.app/?path=/story/components-comboboxfield--default

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [x] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
