### PR TITLE
fix: drawer layout and animation bugs

### DIFF
--- a/.changeset/four-pianos-appear.md
+++ b/.changeset/four-pianos-appear.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fixes push layout bug with drawer. Instead of pushing content out of the way, push incorrectly and permanently occupied layout space.

--- a/.changeset/four-pianos-appear.md
+++ b/.changeset/four-pianos-appear.md
@@ -2,4 +2,4 @@
 "@accelint/design-toolkit": patch
 ---
 
-Fixes push layout bug with drawer. Instead of pushing content out of the way, push incorrectly and permanently occupied layout space.
+Fix Drawer push layout: closed drawers no longer permanently reserve layout space. Each drawer's grid track collapses when closed and expands only when open, so content is pushed aside only while a drawer is open.

--- a/packages/design-toolkit/src/components/drawer/layout.stories.tsx
+++ b/packages/design-toolkit/src/components/drawer/layout.stories.tsx
@@ -280,3 +280,117 @@ export const Default: Story = {
     </div>
   ),
 };
+
+export const MixedSizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four drawers open at once, each with a different `size`. Every edge sizes its own grid track independently, so the large left drawer and small right drawer render at their own widths with no cross-talk between edges.',
+      },
+    },
+  },
+  render: () => (
+    <div className='h-screen w-full'>
+      <DrawerLayout extend='left right' push='left right top bottom'>
+        <DrawerLayoutMain>
+          <div className='flex h-full items-center justify-center bg-surface-overlay'>
+            <p>Main content is pushed by each open drawer.</p>
+          </div>
+        </DrawerLayoutMain>
+
+        <Drawer
+          id={ids.left.drawer}
+          className='bg-[#ffd90087]'
+          placement='left'
+          size='large'
+          defaultView={ids.left.views.a}
+        >
+          <DrawerMenu position='center'>
+            <DrawerMenuItem toggle for={ids.left.views.a} textValue='Left'>
+              <ChevronRight className='fg-primary-bold cursor-pointer group-open/drawer:rotate-180' />
+            </DrawerMenuItem>
+          </DrawerMenu>
+          <DrawerPanel>
+            <DrawerView id={ids.left.views.a}>
+              <DrawerHeader>
+                <DrawerHeaderTitle>Left (large)</DrawerHeaderTitle>
+                <DrawerClose for={ids.left.views.a} />
+              </DrawerHeader>
+              <DrawerContent>Large drawer</DrawerContent>
+            </DrawerView>
+          </DrawerPanel>
+        </Drawer>
+
+        <Drawer
+          id={ids.right.drawer}
+          className='bg-[#00800084]'
+          placement='right'
+          size='small'
+          defaultView={ids.right.views.a}
+        >
+          <DrawerMenu position='center'>
+            <DrawerMenuItem toggle for={ids.right.views.a} textValue='Right'>
+              <ChevronLeft className='fg-primary-bold cursor-pointer group-open/drawer:rotate-180' />
+            </DrawerMenuItem>
+          </DrawerMenu>
+          <DrawerPanel>
+            <DrawerView id={ids.right.views.a}>
+              <DrawerHeader>
+                <DrawerHeaderTitle>Right (small)</DrawerHeaderTitle>
+                <DrawerClose for={ids.right.views.a} />
+              </DrawerHeader>
+              <DrawerContent>Small drawer</DrawerContent>
+            </DrawerView>
+          </DrawerPanel>
+        </Drawer>
+
+        <Drawer
+          id={ids.top.drawer}
+          className='bg-[#ff00008b]'
+          placement='top'
+          size='medium'
+          defaultView={ids.top.views.a}
+        >
+          <DrawerMenu position='center'>
+            <DrawerMenuItem toggle for={ids.top.views.a} textValue='Top'>
+              <ChevronDown className='fg-primary-bold cursor-pointer group-open/drawer:rotate-180' />
+            </DrawerMenuItem>
+          </DrawerMenu>
+          <DrawerPanel>
+            <DrawerView id={ids.top.views.a}>
+              <DrawerHeader>
+                <DrawerHeaderTitle>Top (medium)</DrawerHeaderTitle>
+                <DrawerClose for={ids.top.views.a} />
+              </DrawerHeader>
+              <DrawerContent>Medium drawer</DrawerContent>
+            </DrawerView>
+          </DrawerPanel>
+        </Drawer>
+
+        <Drawer
+          id={ids.bottom.drawer}
+          className='bg-[#0000ff8a]'
+          placement='bottom'
+          size='large'
+          defaultView={ids.bottom.views.a}
+        >
+          <DrawerMenu position='center'>
+            <DrawerMenuItem toggle for={ids.bottom.views.a} textValue='Bottom'>
+              <ChevronUp className='fg-primary-bold cursor-pointer group-open/drawer:rotate-180' />
+            </DrawerMenuItem>
+          </DrawerMenu>
+          <DrawerPanel>
+            <DrawerView id={ids.bottom.views.a}>
+              <DrawerHeader>
+                <DrawerHeaderTitle>Bottom (large)</DrawerHeaderTitle>
+                <DrawerClose for={ids.bottom.views.a} />
+              </DrawerHeader>
+              <DrawerContent>Large drawer</DrawerContent>
+            </DrawerView>
+          </DrawerPanel>
+        </Drawer>
+      </DrawerLayout>
+    </div>
+  ),
+};

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -19,6 +19,11 @@
     --drawer-size-medium: 200px;
     --drawer-size-large: 400px;
 
+    --drawer-left-size: 0px;
+    --drawer-right-size: 0px;
+    --drawer-top-size: 0px;
+    --drawer-bottom-size: 0px;
+
     --drawer-main-row-start: 1;
     --drawer-main-col-end: 4;
     --drawer-main-row-end: 4;
@@ -30,8 +35,16 @@
       var(--drawer-main-row-end);
 
     @apply relative grid h-full w-full overflow-hidden;
-    grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto 1fr auto;
+    grid-template-columns: var(--drawer-left-size) 1fr var(--drawer-right-size);
+    grid-template-rows: var(--drawer-top-size) 1fr var(--drawer-bottom-size);
+
+    @variant motion-safe {
+      transition:
+        grid-template-columns var(--animation-duration-slow)
+          var(--animation-easing-standard),
+        grid-template-rows var(--animation-duration-slow)
+          var(--animation-easing-standard);
+    }
 
     @variant push-top {
       --drawer-main-row-start: 2;
@@ -52,6 +65,54 @@
     @variant has-[.group\/sidenav] {
       --drawer-main-col-start: 2;
     }
+
+    @variant has-[[data-placement=left][data-open]] {
+      @variant has-[[data-size=large]] {
+        --drawer-left-size: var(--drawer-size-large);
+      }
+      @variant has-[[data-size=medium]] {
+        --drawer-left-size: var(--drawer-size-medium);
+      }
+      @variant has-[[data-size=small]] {
+        --drawer-left-size: var(--drawer-size-small);
+      }
+    }
+
+    @variant has-[[data-placement=right][data-open]] {
+      @variant has-[[data-size=large]] {
+        --drawer-right-size: var(--drawer-size-large);
+      }
+      @variant has-[[data-size=medium]] {
+        --drawer-right-size: var(--drawer-size-medium);
+      }
+      @variant has-[[data-size=small]] {
+        --drawer-right-size: var(--drawer-size-small);
+      }
+    }
+
+    @variant has-[[data-placement=top][data-open]] {
+      @variant has-[[data-size=large]] {
+        --drawer-top-size: var(--drawer-size-large);
+      }
+      @variant has-[[data-size=medium]] {
+        --drawer-top-size: var(--drawer-size-medium);
+      }
+      @variant has-[[data-size=small]] {
+        --drawer-top-size: var(--drawer-size-small);
+      }
+    }
+
+    @variant has-[[data-placement=bottom][data-open]] {
+      @variant has-[[data-size=large]] {
+        --drawer-bottom-size: var(--drawer-size-large);
+      }
+      @variant has-[[data-size=medium]] {
+        --drawer-bottom-size: var(--drawer-size-medium);
+      }
+      @variant has-[[data-size=small]] {
+        --drawer-bottom-size: var(--drawer-size-small);
+      }
+    }
   }
 
   .main {
@@ -60,30 +121,18 @@
 
   .drawer {
     @apply bg-surface-default text-body-m pointer-events-none relative flex flex-col;
-
-    @variant motion-safe {
-      transition: transform var(--animation-duration-slow)
-        var(--animation-easing-standard);
-    }
+    min-width: 0;
+    min-height: 0;
 
     @variant placement-top {
       @apply col-span-full row-start-1 row-end-2;
-      transform: translateY(-100%);
-
-      @variant open {
-        transform: translateY(0);
-      }
 
       @variant group-extend-right/layout {
-        @variant group-has-[[data-placement=right][data-open]]/layout {
-          @apply col-end-3;
-        }
+        @apply col-end-3;
       }
 
       @variant group-extend-left/layout {
-        @variant group-has-[[data-placement=left][data-open]]/layout {
-          @apply col-start-2;
-        }
+        @apply col-start-2;
       }
 
       @variant group-data-[extend=bottom]/layout {
@@ -93,22 +142,13 @@
 
     @variant placement-right {
       @apply col-start-3 col-end-4 row-span-full;
-      transform: translateX(100%);
-
-      @variant open {
-        transform: translateX(0);
-      }
 
       @variant group-extend-top/layout {
-        @variant group-has-[[data-placement=top][data-open]]/layout {
-          @apply row-start-2;
-        }
+        @apply row-start-2;
       }
 
       @variant group-extend-bottom/layout {
-        @variant group-has-[[data-placement=bottom][data-open]]/layout {
-          @apply row-end-3;
-        }
+        @apply row-end-3;
       }
 
       @variant group-data-[extend=left]/layout {
@@ -118,22 +158,13 @@
 
     @variant placement-bottom {
       @apply col-span-full row-start-3 row-end-4;
-      transform: translateY(100%);
-
-      @variant open {
-        transform: translateY(0);
-      }
 
       @variant group-extend-right/layout {
-        @variant group-has-[[data-placement=right][data-open]]/layout {
-          @apply col-end-3;
-        }
+        @apply col-end-3;
       }
 
       @variant group-extend-left/layout {
-        @variant group-has-[[data-placement=left][data-open]]/layout {
-          @apply col-start-2;
-        }
+        @apply col-start-2;
       }
 
       @variant group-data-[extend=top]/layout {
@@ -143,22 +174,13 @@
 
     @variant placement-left {
       @apply col-start-1 col-end-2 row-span-full;
-      transform: translateX(-100%);
-
-      @variant open {
-        transform: translateX(0);
-      }
 
       @variant group-extend-top/layout {
-        @variant group-has-[[data-placement=top][data-open]]/layout {
-          @apply row-start-2;
-        }
+        @apply row-start-2;
       }
 
       @variant group-extend-bottom/layout {
-        @variant group-has-[[data-placement=bottom][data-open]]/layout {
-          @apply row-end-3;
-        }
+        @apply row-end-3;
       }
 
       @variant group-data-[extend=right]/layout {
@@ -246,97 +268,10 @@
   }
 
   .panel {
-    @apply gap-s p-l flex h-full min-h-0 flex-col;
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-
-    @variant motion-safe {
-      transition:
-        transform var(--animation-duration-fast)
-          var(--animation-easing-standard),
-        opacity var(--animation-duration-fast) var(--animation-easing-standard),
-        visibility 0s var(--animation-duration-fast);
-    }
-
-    @variant group-placement-left/drawer {
-      transform: translateX(-100%);
-    }
-
-    @variant group-placement-right/drawer {
-      transform: translateX(100%);
-    }
-
-    @variant group-placement-top/drawer {
-      transform: translateY(-100%);
-    }
-
-    @variant group-placement-bottom/drawer {
-      transform: translateY(100%);
-    }
+    @apply gap-s p-l flex hidden h-full min-h-0 flex-col overflow-hidden;
 
     @variant group-open/drawer {
-      opacity: 1;
-      pointer-events: auto;
-      visibility: visible;
-      transform: translate(0, 0);
-      transition-delay: 0s;
-    }
-
-    @variant group-placement-left/drawer {
-      @variant group-size-large/drawer {
-        @apply w-(--drawer-size-large);
-      }
-
-      @variant group-size-medium/drawer {
-        @apply w-(--drawer-size-medium);
-      }
-
-      @variant group-size-small/drawer {
-        @apply w-(--drawer-size-small);
-      }
-    }
-
-    @variant group-placement-right/drawer {
-      @variant group-size-large/drawer {
-        @apply w-(--drawer-size-large);
-      }
-
-      @variant group-size-medium/drawer {
-        @apply w-(--drawer-size-medium);
-      }
-
-      @variant group-size-small/drawer {
-        @apply w-(--drawer-size-small);
-      }
-    }
-
-    @variant group-placement-top/drawer {
-      @variant group-size-large/drawer {
-        @apply h-(--drawer-size-large);
-      }
-
-      @variant group-size-medium/drawer {
-        @apply h-(--drawer-size-medium);
-      }
-
-      @variant group-size-small/drawer {
-        @apply h-(--drawer-size-small);
-      }
-    }
-
-    @variant group-placement-bottom/drawer {
-      @variant group-size-large/drawer {
-        @apply h-(--drawer-size-large);
-      }
-
-      @variant group-size-medium/drawer {
-        @apply h-(--drawer-size-medium);
-      }
-
-      @variant group-size-small/drawer {
-        @apply h-(--drawer-size-small);
-      }
+      @apply flex;
     }
   }
 

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -66,52 +66,44 @@
       --drawer-main-col-start: 2;
     }
 
-    @variant has-[[data-placement=left][data-open]] {
-      @variant has-size-large {
-        --drawer-left-size: var(--drawer-size-large);
-      }
-      @variant has-size-medium {
-        --drawer-left-size: var(--drawer-size-medium);
-      }
-      @variant has-size-small {
-        --drawer-left-size: var(--drawer-size-small);
-      }
+    @variant has-[[data-placement=left][data-open][data-size=large]] {
+      --drawer-left-size: var(--drawer-size-large);
+    }
+    @variant has-[[data-placement=left][data-open][data-size=medium]] {
+      --drawer-left-size: var(--drawer-size-medium);
+    }
+    @variant has-[[data-placement=left][data-open][data-size=small]] {
+      --drawer-left-size: var(--drawer-size-small);
     }
 
-    @variant has-[[data-placement=right][data-open]] {
-      @variant has-size-large {
-        --drawer-right-size: var(--drawer-size-large);
-      }
-      @variant has-size-medium {
-        --drawer-right-size: var(--drawer-size-medium);
-      }
-      @variant has-size-small {
-        --drawer-right-size: var(--drawer-size-small);
-      }
+    @variant has-[[data-placement=right][data-open][data-size=large]] {
+      --drawer-right-size: var(--drawer-size-large);
+    }
+    @variant has-[[data-placement=right][data-open][data-size=medium]] {
+      --drawer-right-size: var(--drawer-size-medium);
+    }
+    @variant has-[[data-placement=right][data-open][data-size=small]] {
+      --drawer-right-size: var(--drawer-size-small);
     }
 
-    @variant has-[[data-placement=top][data-open]] {
-      @variant has-size-large {
-        --drawer-top-size: var(--drawer-size-large);
-      }
-      @variant has-size-medium {
-        --drawer-top-size: var(--drawer-size-medium);
-      }
-      @variant has-size-small {
-        --drawer-top-size: var(--drawer-size-small);
-      }
+    @variant has-[[data-placement=top][data-open][data-size=large]] {
+      --drawer-top-size: var(--drawer-size-large);
+    }
+    @variant has-[[data-placement=top][data-open][data-size=medium]] {
+      --drawer-top-size: var(--drawer-size-medium);
+    }
+    @variant has-[[data-placement=top][data-open][data-size=small]] {
+      --drawer-top-size: var(--drawer-size-small);
     }
 
-    @variant has-[[data-placement=bottom][data-open]] {
-      @variant has-size-large {
-        --drawer-bottom-size: var(--drawer-size-large);
-      }
-      @variant has-size-medium {
-        --drawer-bottom-size: var(--drawer-size-medium);
-      }
-      @variant has-size-small {
-        --drawer-bottom-size: var(--drawer-size-small);
-      }
+    @variant has-[[data-placement=bottom][data-open][data-size=large]] {
+      --drawer-bottom-size: var(--drawer-size-large);
+    }
+    @variant has-[[data-placement=bottom][data-open][data-size=medium]] {
+      --drawer-bottom-size: var(--drawer-size-medium);
+    }
+    @variant has-[[data-placement=bottom][data-open][data-size=small]] {
+      --drawer-bottom-size: var(--drawer-size-small);
     }
   }
 
@@ -268,7 +260,7 @@
   }
 
   .panel {
-    @apply gap-s p-l flex hidden h-full min-h-0 flex-col overflow-hidden;
+    @apply gap-s p-l hidden h-full min-h-0 flex-col overflow-hidden;
 
     @variant group-open/drawer {
       @apply flex;

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -67,49 +67,49 @@
     }
 
     @variant has-[[data-placement=left][data-open]] {
-      @variant has-[[data-size=large]] {
+      @variant has-size-large {
         --drawer-left-size: var(--drawer-size-large);
       }
-      @variant has-[[data-size=medium]] {
+      @variant has-size-medium {
         --drawer-left-size: var(--drawer-size-medium);
       }
-      @variant has-[[data-size=small]] {
+      @variant has-size-small {
         --drawer-left-size: var(--drawer-size-small);
       }
     }
 
     @variant has-[[data-placement=right][data-open]] {
-      @variant has-[[data-size=large]] {
+      @variant has-size-large {
         --drawer-right-size: var(--drawer-size-large);
       }
-      @variant has-[[data-size=medium]] {
+      @variant has-size-medium {
         --drawer-right-size: var(--drawer-size-medium);
       }
-      @variant has-[[data-size=small]] {
+      @variant has-size-small {
         --drawer-right-size: var(--drawer-size-small);
       }
     }
 
     @variant has-[[data-placement=top][data-open]] {
-      @variant has-[[data-size=large]] {
+      @variant has-size-large {
         --drawer-top-size: var(--drawer-size-large);
       }
-      @variant has-[[data-size=medium]] {
+      @variant has-size-medium {
         --drawer-top-size: var(--drawer-size-medium);
       }
-      @variant has-[[data-size=small]] {
+      @variant has-size-small {
         --drawer-top-size: var(--drawer-size-small);
       }
     }
 
     @variant has-[[data-placement=bottom][data-open]] {
-      @variant has-[[data-size=large]] {
+      @variant has-size-large {
         --drawer-bottom-size: var(--drawer-size-large);
       }
-      @variant has-[[data-size=medium]] {
+      @variant has-size-medium {
         --drawer-bottom-size: var(--drawer-size-medium);
       }
-      @variant has-[[data-size=small]] {
+      @variant has-size-small {
         --drawer-bottom-size: var(--drawer-size-small);
       }
     }


### PR DESCRIPTION
Closes [Issue 116](https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/116)

Recently, we discovered some layout bugs for the drawer that were all related to the changes made when [implementing animation](https://github.com/gohypergiant/standard-toolkit/pull/936). 

First, the content was sliding out the frame for the drawer but not truly collapsed, which caused scrollbars to show. Second, the remaining drawers in a layout didn't expand to fill space when an adjacent drawer was closed. You can see the fix in place for those two bugs in this PR:

https://github.com/gohypergiant/standard-toolkit/pull/1005

But then we found yet another bug: the push wasn't working correctly to "push" content out of the way when the door was opened/closed.

https://github.com/user-attachments/assets/fa3e67f8-8092-4aa1-a845-688ec7c44497

Because this was the third bug found using the transform/translate method for animation, we decided to rework the component layout completely to animate the grid, for a more flexible and less brittle implementation.


## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

[Review the drawer layout stories in storybook](https://design-toolkit-git-fix-drawer-layout-accelint.vercel.app/) to ensure that all the previous regressions are fixed:

1. drawers expand collapse correctly when there are multiple drawers in a layout
2. push works as expected to push and collapse the main layout content
3. there is no additional scrolling when drawers are closed

It would also be lovely to just do a general regression smoke test to make sure there aren't any more unpleasant surprises.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
