### PR TITLE
fix: prevent checkbox and switch scroll-into-view behavior

### DIFF
--- a/.changeset/swift-foxes-dance.md
+++ b/.changeset/swift-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fix checkbox scroll-into-view behavior. Prevents browser from automatically scrolling when clicking checkboxes by overriding focus() to use preventScroll option.

--- a/.changeset/swift-foxes-dance.md
+++ b/.changeset/swift-foxes-dance.md
@@ -2,4 +2,4 @@
 "@accelint/design-toolkit": patch
 ---
 
-Fix checkbox scroll-into-view behavior. Prevents browser from automatically scrolling when clicking checkboxes by overriding focus() to use preventScroll option.
+Fix checkbox and switch scroll-into-view behavior. Prevents browser from automatically scrolling when clicking checkboxes or switches by overriding focus() to use preventScroll option.

--- a/packages/design-toolkit/package.json
+++ b/packages/design-toolkit/package.json
@@ -421,6 +421,7 @@
     "./hooks/coordinate-field/use-timeout-cleanup": "./dist/hooks/coordinate-field/use-timeout-cleanup.js",
     "./hooks/kanban": "./dist/hooks/kanban/index.js",
     "./hooks/use-frame-delay": "./dist/hooks/use-frame-delay/index.js",
+    "./hooks/use-prevent-scroll-focus": "./dist/hooks/use-prevent-scroll-focus/index.js",
     "./hooks/use-tree/actions": "./dist/hooks/use-tree/actions/index.js",
     "./hooks/use-tree/actions/cache": "./dist/hooks/use-tree/actions/cache.js",
     "./hooks/use-tree/state": "./dist/hooks/use-tree/state/index.js",

--- a/packages/design-toolkit/package.json
+++ b/packages/design-toolkit/package.json
@@ -421,7 +421,6 @@
     "./hooks/coordinate-field/use-timeout-cleanup": "./dist/hooks/coordinate-field/use-timeout-cleanup.js",
     "./hooks/kanban": "./dist/hooks/kanban/index.js",
     "./hooks/use-frame-delay": "./dist/hooks/use-frame-delay/index.js",
-    "./hooks/use-prevent-scroll-focus": "./dist/hooks/use-prevent-scroll-focus/index.js",
     "./hooks/use-tree/actions": "./dist/hooks/use-tree/actions/index.js",
     "./hooks/use-tree/actions/cache": "./dist/hooks/use-tree/actions/cache.js",
     "./hooks/use-tree/state": "./dist/hooks/use-tree/state/index.js",

--- a/packages/design-toolkit/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/design-toolkit/src/components/checkbox/checkbox.stories.tsx
@@ -38,8 +38,18 @@ export const Default: Story = {
 
 export const ScrollPreventionTest: Story = {
   render: () => (
-    <div style={{ height: '400px', overflow: 'auto', border: '2px solid #ccc', padding: '20px' }}>
-      <p>Scroll down and click checkboxes - the viewport should not jump or scroll</p>
+    <div
+      style={{
+        height: '400px',
+        overflow: 'auto',
+        border: '2px solid #ccc',
+        padding: '20px',
+      }}
+    >
+      <p>
+        Scroll down and click checkboxes - the viewport should not jump or
+        scroll
+      </p>
       <div style={{ height: '200px' }} />
       {Array.from({ length: 20 }, (_, i) => (
         <div key={i} style={{ marginBottom: '20px' }}>
@@ -52,7 +62,8 @@ export const ScrollPreventionTest: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Tests that clicking checkboxes does not cause unwanted scroll-into-view behavior. Scroll within the container and click checkboxes - the viewport should remain stable.',
+        story:
+          'Tests that clicking checkboxes does not cause unwanted scroll-into-view behavior. Scroll within the container and click checkboxes - the viewport should remain stable.',
       },
     },
   },

--- a/packages/design-toolkit/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/design-toolkit/src/components/checkbox/checkbox.stories.tsx
@@ -35,3 +35,25 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: ({ children, ...args }) => <Checkbox {...args}>Unsubscribe</Checkbox>,
 };
+
+export const ScrollPreventionTest: Story = {
+  render: () => (
+    <div style={{ height: '400px', overflow: 'auto', border: '2px solid #ccc', padding: '20px' }}>
+      <p>Scroll down and click checkboxes - the viewport should not jump or scroll</p>
+      <div style={{ height: '200px' }} />
+      {Array.from({ length: 20 }, (_, i) => (
+        <div key={i} style={{ marginBottom: '20px' }}>
+          <Checkbox>Checkbox {i + 1}</Checkbox>
+        </div>
+      ))}
+      <div style={{ height: '200px' }} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Tests that clicking checkboxes does not cause unwanted scroll-into-view behavior. Scroll within the container and click checkboxes - the viewport should remain stable.',
+      },
+    },
+  },
+};

--- a/packages/design-toolkit/src/components/checkbox/index.tsx
+++ b/packages/design-toolkit/src/components/checkbox/index.tsx
@@ -14,10 +14,10 @@ import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
 import Check from '@accelint/icons/check';
 import Remove from '@accelint/icons/remove';
-import { useCallback, useRef } from 'react';
 import { Checkbox as AriaCheckbox } from 'react-aria-components/Checkbox';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { useContextProps } from 'react-aria-components/slots';
+import { usePreventScrollFocus } from '../../hooks/use-prevent-scroll-focus';
 import { Icon } from '../icon';
 import { CheckboxContext } from './context';
 import styles from './styles.module.css';
@@ -77,42 +77,12 @@ export function Checkbox({ ref, ...props }: CheckboxProps) {
   [props, ref] = useContextProps(props, ref ?? null, CheckboxContext);
 
   const { classNames, children, labelPosition = 'end', ...rest } = props;
-  const internalRef = useRef<HTMLLabelElement>(null);
-
-  const handleRef = useCallback(
-    (node: HTMLLabelElement | null) => {
-      internalRef.current = node;
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-
-      if (node) {
-        // Override focus on the checkbox label element
-        const originalFocus = node.focus;
-        node.focus = function (options?: FocusOptions) {
-          originalFocus.call(this, { ...options, preventScroll: true });
-        };
-
-        // Also override focus on any input elements inside
-        const inputs = node.querySelectorAll('input');
-        inputs.forEach((input) => {
-          const originalInputFocus = input.focus;
-          input.focus = function (options?: FocusOptions) {
-            originalInputFocus.call(this, { ...options, preventScroll: true });
-          };
-        });
-      }
-    },
-    [ref],
-  );
+  const handleRef = usePreventScrollFocus(ref);
 
   return (
     <AriaCheckbox
       {...rest}
       ref={handleRef}
-      preventFocusOnPress
       className={composeRenderProps(classNames?.checkbox, (className) =>
         clsx(
           'group/checkbox',

--- a/packages/design-toolkit/src/components/checkbox/index.tsx
+++ b/packages/design-toolkit/src/components/checkbox/index.tsx
@@ -14,6 +14,7 @@ import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
 import Check from '@accelint/icons/check';
 import Remove from '@accelint/icons/remove';
+import { useCallback, useRef } from 'react';
 import { Checkbox as AriaCheckbox } from 'react-aria-components/Checkbox';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { useContextProps } from 'react-aria-components/slots';
@@ -76,11 +77,42 @@ export function Checkbox({ ref, ...props }: CheckboxProps) {
   [props, ref] = useContextProps(props, ref ?? null, CheckboxContext);
 
   const { classNames, children, labelPosition = 'end', ...rest } = props;
+  const internalRef = useRef<HTMLLabelElement>(null);
+
+  const handleRef = useCallback(
+    (node: HTMLLabelElement | null) => {
+      internalRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+
+      if (node) {
+        // Override focus on the checkbox label element
+        const originalFocus = node.focus;
+        node.focus = function (options?: FocusOptions) {
+          originalFocus.call(this, { ...options, preventScroll: true });
+        };
+
+        // Also override focus on any input elements inside
+        const inputs = node.querySelectorAll('input');
+        inputs.forEach((input) => {
+          const originalInputFocus = input.focus;
+          input.focus = function (options?: FocusOptions) {
+            originalInputFocus.call(this, { ...options, preventScroll: true });
+          };
+        });
+      }
+    },
+    [ref],
+  );
 
   return (
     <AriaCheckbox
       {...rest}
-      ref={ref}
+      ref={handleRef}
+      preventFocusOnPress
       className={composeRenderProps(classNames?.checkbox, (className) =>
         clsx(
           'group/checkbox',

--- a/packages/design-toolkit/src/components/checkbox/styles.module.css
+++ b/packages/design-toolkit/src/components/checkbox/styles.module.css
@@ -31,6 +31,8 @@
 
   .checkbox {
     @apply gap-m flex cursor-pointer items-center;
+    scroll-margin: 0 !important;
+    scroll-padding: 0 !important;
 
     &.labelStart {
       .label {

--- a/packages/design-toolkit/src/components/switch/index.tsx
+++ b/packages/design-toolkit/src/components/switch/index.tsx
@@ -13,10 +13,10 @@
 
 import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
-import { useCallback, useRef } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { useContextProps } from 'react-aria-components/slots';
 import { Switch as AriaSwitch } from 'react-aria-components/Switch';
+import { usePreventScrollFocus } from '../../hooks/use-prevent-scroll-focus';
 import { SwitchContext } from './context';
 import styles from './styles.module.css';
 import type { SwitchProps } from './types';
@@ -44,36 +44,7 @@ export function Switch({ ref, ...props }: SwitchProps) {
   [props, ref] = useContextProps(props, ref ?? null, SwitchContext);
 
   const { children, classNames, labelPosition = 'end', ...rest } = props;
-  const internalRef = useRef<HTMLLabelElement>(null);
-
-  const handleRef = useCallback(
-    (node: HTMLLabelElement | null) => {
-      internalRef.current = node;
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-
-      if (node) {
-        // Override focus on the switch label element
-        const originalFocus = node.focus;
-        node.focus = function (options?: FocusOptions) {
-          originalFocus.call(this, { ...options, preventScroll: true });
-        };
-
-        // Also override focus on any input elements inside
-        const inputs = node.querySelectorAll('input');
-        inputs.forEach((input) => {
-          const originalInputFocus = input.focus;
-          input.focus = function (options?: FocusOptions) {
-            originalInputFocus.call(this, { ...options, preventScroll: true });
-          };
-        });
-      }
-    },
-    [ref],
-  );
+  const handleRef = usePreventScrollFocus(ref);
 
   return (
     <AriaSwitch

--- a/packages/design-toolkit/src/components/switch/index.tsx
+++ b/packages/design-toolkit/src/components/switch/index.tsx
@@ -13,6 +13,7 @@
 
 import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
+import { useCallback, useRef } from 'react';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { useContextProps } from 'react-aria-components/slots';
 import { Switch as AriaSwitch } from 'react-aria-components/Switch';
@@ -43,11 +44,41 @@ export function Switch({ ref, ...props }: SwitchProps) {
   [props, ref] = useContextProps(props, ref ?? null, SwitchContext);
 
   const { children, classNames, labelPosition = 'end', ...rest } = props;
+  const internalRef = useRef<HTMLLabelElement>(null);
+
+  const handleRef = useCallback(
+    (node: HTMLLabelElement | null) => {
+      internalRef.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+
+      if (node) {
+        // Override focus on the switch label element
+        const originalFocus = node.focus;
+        node.focus = function (options?: FocusOptions) {
+          originalFocus.call(this, { ...options, preventScroll: true });
+        };
+
+        // Also override focus on any input elements inside
+        const inputs = node.querySelectorAll('input');
+        inputs.forEach((input) => {
+          const originalInputFocus = input.focus;
+          input.focus = function (options?: FocusOptions) {
+            originalInputFocus.call(this, { ...options, preventScroll: true });
+          };
+        });
+      }
+    },
+    [ref],
+  );
 
   return (
     <AriaSwitch
       {...rest}
-      ref={ref}
+      ref={handleRef}
       className={composeRenderProps(classNames?.switch, (className) =>
         clsx('group/switch', styles.switch, styles[labelPosition], className),
       )}

--- a/packages/design-toolkit/src/components/switch/styles.module.css
+++ b/packages/design-toolkit/src/components/switch/styles.module.css
@@ -15,6 +15,8 @@
 @layer components.l1 {
   .switch {
     @apply gap-s flex cursor-pointer items-center;
+    scroll-margin: 0 !important;
+    scroll-padding: 0 !important;
 
     @variant disabled {
       @apply cursor-not-allowed;

--- a/packages/design-toolkit/src/components/switch/switch.stories.tsx
+++ b/packages/design-toolkit/src/components/switch/switch.stories.tsx
@@ -34,3 +34,25 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: Switch,
 };
+
+export const ScrollPreventionTest: Story = {
+  render: () => (
+    <div style={{ height: '400px', overflow: 'auto', border: '2px solid #ccc', padding: '20px' }}>
+      <p>Scroll down and click switches - the viewport should not jump or scroll</p>
+      <div style={{ height: '200px' }} />
+      {Array.from({ length: 20 }, (_, i) => (
+        <div key={i} style={{ marginBottom: '20px' }}>
+          <Switch>Switch {i + 1}</Switch>
+        </div>
+      ))}
+      <div style={{ height: '200px' }} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Tests that clicking switches does not cause unwanted scroll-into-view behavior. Scroll within the container and click switches - the viewport should remain stable.',
+      },
+    },
+  },
+};

--- a/packages/design-toolkit/src/components/switch/switch.stories.tsx
+++ b/packages/design-toolkit/src/components/switch/switch.stories.tsx
@@ -37,8 +37,17 @@ export const Default: Story = {
 
 export const ScrollPreventionTest: Story = {
   render: () => (
-    <div style={{ height: '400px', overflow: 'auto', border: '2px solid #ccc', padding: '20px' }}>
-      <p>Scroll down and click switches - the viewport should not jump or scroll</p>
+    <div
+      style={{
+        height: '400px',
+        overflow: 'auto',
+        border: '2px solid #ccc',
+        padding: '20px',
+      }}
+    >
+      <p>
+        Scroll down and click switches - the viewport should not jump or scroll
+      </p>
       <div style={{ height: '200px' }} />
       {Array.from({ length: 20 }, (_, i) => (
         <div key={i} style={{ marginBottom: '20px' }}>
@@ -51,7 +60,8 @@ export const ScrollPreventionTest: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Tests that clicking switches does not cause unwanted scroll-into-view behavior. Scroll within the container and click switches - the viewport should remain stable.',
+        story:
+          'Tests that clicking switches does not cause unwanted scroll-into-view behavior. Scroll within the container and click switches - the viewport should remain stable.',
       },
     },
   },

--- a/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
+++ b/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { useCallback, useRef } from 'react';
+import type { Ref } from 'react';
+
+/**
+ * Custom hook that prevents scroll-into-view behavior when focus is triggered
+ * on an element and its child inputs.
+ *
+ * This hook overrides the native focus() method on both the target element and
+ * any input elements within it to always pass { preventScroll: true }, preventing
+ * the browser from automatically scrolling the element into view when focused.
+ *
+ * @param ref - External ref to merge with internal ref
+ * @returns A ref callback that overrides focus behavior with preventScroll
+ *
+ * @example
+ * ```tsx
+ * function MyComponent({ ref, ...props }) {
+ *   const handleRef = usePreventScrollFocus(ref);
+ *   return <label ref={handleRef}>...</label>;
+ * }
+ * ```
+ */
+export function usePreventScrollFocus<T extends HTMLElement = HTMLLabelElement>(
+  ref: Ref<T> | null | undefined,
+) {
+  const internalRef = useRef<T>(null);
+
+  const handleRef = useCallback(
+    (node: T | null) => {
+      internalRef.current = node;
+
+      // Merge with external ref
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as any).current = node;
+      }
+
+      if (node) {
+        // Override focus on the element
+        const originalFocus = node.focus;
+        node.focus = function (options?: FocusOptions) {
+          originalFocus.call(this, { ...options, preventScroll: true });
+        };
+
+        // Also override focus on any input elements inside
+        const inputs = node.querySelectorAll('input');
+        inputs.forEach((input) => {
+          const originalInputFocus = input.focus;
+          input.focus = function (options?: FocusOptions) {
+            originalInputFocus.call(this, { ...options, preventScroll: true });
+          };
+        });
+      }
+    },
+    [ref],
+  );
+
+  return handleRef;
+}

--- a/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
+++ b/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
@@ -49,19 +49,27 @@ export function usePreventScrollFocus<T extends HTMLElement = HTMLLabelElement>(
       }
 
       if (node) {
-        // Override focus on the element
-        const originalFocus = node.focus;
-        node.focus = function (options?: FocusOptions) {
-          originalFocus.call(this, { ...options, preventScroll: true });
-        };
+        // Override focus on the element (skip in test environments where focus is read-only)
+        try {
+          const originalFocus = node.focus;
+          node.focus = function (options?: FocusOptions) {
+            originalFocus.call(this, { ...options, preventScroll: true });
+          };
+        } catch {
+          // In test environments (jsdom), focus is read-only and cannot be overridden
+        }
 
         // Also override focus on any input elements inside
         const inputs = node.querySelectorAll('input');
         inputs.forEach((input) => {
-          const originalInputFocus = input.focus;
-          input.focus = function (options?: FocusOptions) {
-            originalInputFocus.call(this, { ...options, preventScroll: true });
-          };
+          try {
+            const originalInputFocus = input.focus;
+            input.focus = function (options?: FocusOptions) {
+              originalInputFocus.call(this, { ...options, preventScroll: true });
+            };
+          } catch {
+            // In test environments (jsdom), focus is read-only and cannot be overridden
+          }
         });
       }
     },

--- a/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
+++ b/packages/design-toolkit/src/hooks/use-prevent-scroll-focus/index.ts
@@ -65,7 +65,10 @@ export function usePreventScrollFocus<T extends HTMLElement = HTMLLabelElement>(
           try {
             const originalInputFocus = input.focus;
             input.focus = function (options?: FocusOptions) {
-              originalInputFocus.call(this, { ...options, preventScroll: true });
+              originalInputFocus.call(this, {
+                ...options,
+                preventScroll: true,
+              });
             };
           } catch {
             // In test environments (jsdom), focus is read-only and cannot be overridden

--- a/packages/design-toolkit/src/index.ts
+++ b/packages/design-toolkit/src/index.ts
@@ -685,6 +685,7 @@ export type {
   UseFrameDelayOptions,
   UseFrameDelayResult,
 } from './hooks/use-frame-delay';
+export { usePreventScrollFocus } from './hooks/use-prevent-scroll-focus';
 export { useTreeActions } from './hooks/use-tree/actions';
 export { useTreeState } from './hooks/use-tree/state';
 export type {

--- a/packages/design-toolkit/src/index.ts
+++ b/packages/design-toolkit/src/index.ts
@@ -685,7 +685,6 @@ export type {
   UseFrameDelayOptions,
   UseFrameDelayResult,
 } from './hooks/use-frame-delay';
-export { usePreventScrollFocus } from './hooks/use-prevent-scroll-focus';
 export { useTreeActions } from './hooks/use-tree/actions';
 export { useTreeState } from './hooks/use-tree/state';
 export type {


### PR DESCRIPTION
https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/118
                                                                                                                                    
  ## ✅ Pull Request Checklist                                                                                                      
                                                                                                                                    
  - [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).                     
  - [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.                                      
  - [x] Added/updated unit tests and storybook for this change (for bug fixes / features).                                          
  - [ ] Added/updated visual regression tests for this change (for bug fixes / features).                                           
  - [ ] Added/updated documentation (for bug fixes / features)                                                                      
  - [x] Filled out test instructions.                                                                                               
  - [x] Added changeset (for bug fixes / features).                                                                                 
                                                                                                                                    
  ## 📝 Test Instructions                                                                                                           
                                                                                 
  **Problem**: Clicking checkboxes in tables caused the browser to automatically scroll the element into view, disrupting the user's
   viewport position.                                         
                                                                                                                                    
  **To test the fix**:                                                                                                              
  1. Create a table or list with multiple rows of checkboxes                             
  2. Scroll the viewport so that some checkboxes are above/below the visible area                                                   
  3. Click a checkbox that is near the edge of the viewport                                                                         
  4. Verify that the viewport does not jump or scroll to the clicked checkbox                                                       
                                                                                                                                    
  **Root Cause**: React Aria Components' Checkbox calls `element.focus()` without the `preventScroll` option, triggering the        
  browser's default scroll-on-focus behavior.                                                                                       
                                                                                                                                    
  **Solution**:                                                                                                                     
  - Override `focus()` method on checkbox label and input elements to always pass `{ preventScroll: true }`
  - Add `preventFocusOnPress` prop to React Aria's Checkbox component                                                               
  - Add CSS `scroll-margin: 0` and `scroll-padding: 0` as additional safeguards                                                     
                                                                                                                                    
  **Files Changed**:                                                                                                                
  - `packages/design-toolkit/src/components/checkbox/index.tsx`                                                                     
  - `packages/design-toolkit/src/components/checkbox/styles.module.css`                                                             
                                                                                                                                    
  ## ❓ Does this PR introduce a breaking change?                                                                                   
                                                                                                                                    
  - [ ] Yes                                                                                                                         
  - [x] No                                                                       
                                                                                                                                    
  ## 🤖 AI Usage
                                                                                                                                    
  - [x] Added corresponding label (ai / human) to PR:                                                                               
                                                                                 
  If ai was used, select all that apply:                                                                                            
  - [ ] Ideation / brainstorming                              
  - [ ] Documentation                                                                                                               
  - [x] Testing
  - [x] Implementation                                                                                                              
                                                              
  AI (Claude Code) was used for code formatting verification, lint checks, and implementing the focus override pattern.             
   
  ## 💬 Other information                                                                                                           
                                                              
  This fix prevents unwanted scroll behavior that was particularly disruptive in table views with many rows. The implementation uses
   a ref callback to intercept focus calls at the DOM level, ensuring `preventScroll: true` is always applied regardless of how
  focus is triggered. 