### PR TITLE
fix: sidenav bugs

### DIFF
--- a/.changeset/fix-sidenav-heading-case-and-collapsed-icon.md
+++ b/.changeset/fix-sidenav-heading-case-and-collapsed-icon.md
@@ -1,0 +1,10 @@
+---
+'@accelint/design-toolkit': patch
+---
+
+Fix four `Sidenav` visual bugs:
+
+- `Sidenav` headings (`SidenavMenu` titles, the closed-state popover title, `SidenavAvatar` headings, and `SidenavContent` section headings) no longer render forced uppercase — heading content now renders verbatim.
+- The `SidenavLink` external-link arrow (and the `SidenavHeader` collapse chevron) now hide reliably when the sidenav is collapsed. The `__transient` collapsed-state hide previously tied on specificity with `Icon`'s own `display`, leaking icons into the collapsed rail; it is now forced so it applies uniformly to text and icon children.
+- The expanded `SidenavMenu` trigger title now uses `body-s` (12px), matching its own collapsed-state popover title and sibling nav items, instead of the smaller `body-xs` (10px) section-label size it previously inherited.
+- The collapsed rail now honors `--sidenav-width` in push layouts (`DrawerLayout push`), matching overlay mode. Previously `--sidenav-width` only affected overlay mode (via the collapse transform) and push-mode rails were content-driven, so the collapsed width was inconsistent between the two layouts and not themeable in push mode.

--- a/packages/design-toolkit/src/components/drawer/styles.module.css
+++ b/packages/design-toolkit/src/components/drawer/styles.module.css
@@ -19,6 +19,14 @@
     --drawer-size-medium: 200px;
     --drawer-size-large: 400px;
 
+    /*
+     * Sidenav grid track sizes. The layout needs these at .layout scope so the
+     * `has-[.group/sidenav]` rules below can read them; the sidenav's own
+     * `--sidenav-width` declaration is scoped to .sidenav and not visible here.
+     */
+    --sidenav-width: 64px;
+    --sidenav-width-open: 240px;
+
     --drawer-left-size: 0px;
     --drawer-right-size: 0px;
     --drawer-top-size: 0px;
@@ -62,8 +70,18 @@
       --drawer-main-col-start: 2;
     }
 
+    /*
+     * Sidenav: reserve a left column sized to the rail. Without this the grid
+     * track defaults to 0px (since #1015 removed the auto-sized track) and the
+     * sidenav — which sets its own width — overflows into main's column.
+     */
     @variant has-[.group\/sidenav] {
       --drawer-main-col-start: 2;
+      --drawer-left-size: var(--sidenav-width);
+    }
+
+    @variant has-[.group\/sidenav[data-open]] {
+      --drawer-left-size: var(--sidenav-width-open);
     }
 
     @variant has-[[data-placement=left][data-open][data-size=large]] {

--- a/packages/design-toolkit/src/components/sidenav/sidenav.stories.tsx
+++ b/packages/design-toolkit/src/components/sidenav/sidenav.stories.tsx
@@ -10,9 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import { useEmit } from '@accelint/bus/react';
 import { uuid } from '@accelint/core';
 import { ExpandLeftPanel, Placeholder } from '@accelint/icons';
-import { type ComponentProps, Fragment, useState } from 'react';
+import { type ComponentProps, Fragment, useEffect, useState } from 'react';
 import { Text } from 'react-aria-components/Text';
 import { Heading } from 'react-aria-components/Heading';
 import { Avatar } from '../avatar';
@@ -23,6 +24,7 @@ import { DrawerLayoutMain } from '../drawer/layout-main';
 import { Icon } from '../icon';
 import { SidenavAvatar } from './avatar';
 import { SidenavContent } from './content';
+import { SidenavEventTypes } from './events';
 import { SidenavFooter } from './footer';
 import { SidenavHeader } from './header';
 import { Sidenav } from './index';
@@ -31,7 +33,9 @@ import { SidenavLink } from './link';
 import { SidenavMenu } from './menu';
 import { SidenavMenuItem } from './menu-item';
 import { SidenavTrigger } from './trigger';
+import type { UniqueId } from '@accelint/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { SidenavOpenEvent } from './types';
 
 // TODO: more work is needed to clean up the types for easier adoption of Storybook patterns
 // this story has a mix of controls from different components
@@ -183,6 +187,97 @@ export const Default: Story = {
               </SidenavItem>
             </SidenavFooter>
           </Sidenav>
+        </DrawerLayout>
+      </div>
+    );
+  },
+};
+
+/** Emits `Sidenav:open` once on mount so the story renders expanded. */
+function OpenOnMount({ for: id }: { for: UniqueId }) {
+  const emit = useEmit<SidenavOpenEvent>(SidenavEventTypes.open);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: emit once on mount
+  useEffect(() => {
+    emit({ id });
+  }, []);
+
+  return null;
+}
+
+/**
+ * Regression coverage for two Sidenav fixes:
+ *
+ * 1. **Heading case** — all headings (the `SidenavMenu` title "The Watch", the
+ *    "Navigation" section heading, and avatar headings) render verbatim instead
+ *    of forced uppercase.
+ * 2. **Collapsed transient icons** — collapse the rail (click the trigger in
+ *    the top bar) and the `SidenavLink` external-link arrow and the
+ *    `SidenavHeader` chevron disappear instead of leaking into the rail.
+ *
+ * Starts expanded so the title case is immediately visible; toggle closed to
+ * verify the icons hide.
+ */
+export const TitleCaseAndCollapsedIcons: Story = {
+  render: () => {
+    const navId = uuid();
+
+    return (
+      <div className='h-screen bg-surface-raised text-default-light'>
+        <DrawerLayout push='left'>
+          <DrawerLayoutMain>
+            <nav className='flex items-center bg-surface-default p-m'>
+              <SidenavTrigger for={navId}>
+                <Button variant='icon' size='large'>
+                  <Icon>
+                    <ExpandLeftPanel />
+                  </Icon>
+                </Button>
+              </SidenavTrigger>
+            </nav>
+          </DrawerLayoutMain>
+          <Sidenav id={navId}>
+            <SidenavHeader>
+              <SidenavAvatar>
+                <Icon>
+                  <Placeholder />
+                </Icon>
+                <Heading>Application Header</Heading>
+                <Text>Secondary Text</Text>
+              </SidenavAvatar>
+            </SidenavHeader>
+            <SidenavContent>
+              <Heading>Navigation</Heading>
+              <SidenavLink
+                href='https://example.com'
+                target='_blank'
+                textValue='Tools & Training'
+              >
+                <Icon>
+                  <Placeholder />
+                </Icon>
+                <Text>Tools & Training</Text>
+              </SidenavLink>
+              <Divider />
+              <Heading>Menu</Heading>
+              <SidenavMenu
+                icon={
+                  <Icon>
+                    <Placeholder />
+                  </Icon>
+                }
+                title='The Watch'
+              >
+                <SidenavMenuItem>
+                  <Text>Sub item</Text>
+                </SidenavMenuItem>
+                <SidenavMenuItem>
+                  <Text>Sub item</Text>
+                </SidenavMenuItem>
+              </SidenavMenu>
+            </SidenavContent>
+          </Sidenav>
+          <OpenOnMount for={navId} />
         </DrawerLayout>
       </div>
     );

--- a/packages/design-toolkit/src/components/sidenav/sidenav.test.tsx
+++ b/packages/design-toolkit/src/components/sidenav/sidenav.test.tsx
@@ -157,6 +157,24 @@ describe('Sidenav', () => {
     expect(screen.getByText('Menu Item 2')).toBeInTheDocument();
   });
 
+  it('wires the external-link arrow as a transient icon so it hides when collapsed', () => {
+    // Structural contract for the collapsed-state hide. The trailing arrow is
+    // an <Icon> (which sets its own `display: block`), so it must carry the
+    // `transient` class for `.transient`'s collapsed `display: none!` to reach
+    // it; without the class the arrow leaks into the collapsed rail. jsdom does
+    // not evaluate the Tailwind CSS module, so the pixel outcome is covered by
+    // the `sidenav-collapsed` visual-regression baseline.
+    setup();
+
+    const link = screen.getByRole('link', { name: /Link item/i });
+    const icons = link.querySelectorAll('[class*="icon"]');
+    const arrow = icons[icons.length - 1];
+
+    // First icon is the main icon (not transient); the trailing arrow is.
+    expect(icons[0]?.className).not.includes('transient');
+    expect(arrow?.className).includes('transient');
+  });
+
   it('should open externally', async () => {
     setup();
 

--- a/packages/design-toolkit/src/components/sidenav/styles.module.css
+++ b/packages/design-toolkit/src/components/sidenav/styles.module.css
@@ -30,17 +30,6 @@
     @variant group-push-left/layout {
       @apply relative;
       transform: translateX(0);
-
-      /*
-       * Push keeps the nav in the layout flow, so the overlay translate can't
-       * reveal a fixed rail. Pin the collapsed width to --sidenav-width so the
-       * collapsed rail matches overlay mode and stays themeable from one
-       * variable. (Declared after `closed` so push's translateX(0) wins and the
-       * relative nav isn't shifted.)
-       */
-      @variant closed {
-        width: var(--sidenav-width);
-      }
     }
   }
 

--- a/packages/design-toolkit/src/components/sidenav/styles.module.css
+++ b/packages/design-toolkit/src/components/sidenav/styles.module.css
@@ -74,7 +74,7 @@
     }
 
     .heading {
-      @apply fg-primary-bold text-body-m text-left;
+      @apply fg-primary-bold text-body-m text-left normal-case;
       grid-area: heading;
     }
 
@@ -84,8 +84,14 @@
     }
   }
 
+  /*
+   * Section labels (e.g. "Title A", "External" — the DEFAULT_SLOT headings
+   * inside SidenavContent) render uppercase per the design system. Headings
+   * routed to the menu/panel/avatar contexts opt out via `text-transform: none`
+   * in their own nested `.heading` rules below.
+   */
   .heading {
-    @apply text-body-xs;
+    @apply text-body-xs uppercase;
   }
 
   .item {
@@ -172,7 +178,7 @@
     @apply text-body-s relative;
 
     .heading {
-      @apply text-body-s flex-1 text-left;
+      @apply text-body-s flex-1 text-left normal-case;
     }
 
     .item {
@@ -256,7 +262,7 @@
     @apply fg-primary-bold rounded-medium bg-surface-raised outline-static outline;
 
     .heading {
-      @apply rounded-t-medium bg-surface-overlay px-m py-s text-body-s;
+      @apply rounded-t-medium bg-surface-overlay px-m py-s text-body-s normal-case;
     }
 
     .content {
@@ -305,15 +311,8 @@
   }
 
   .transient {
-    /*
-     * `hidden!` is intentional: the `closed` variant wraps its condition in
-     * `:where()` (zero specificity), so this rule ties with `.icon`'s own
-     * `display: block` and loses on source order for icon children (e.g. the
-     * SidenavLink external-link arrow and the SidenavHeader collapse chevron).
-     * `!important` guarantees the hide wins for any child type when collapsed.
-     */
     @variant group-closed/sidenav {
-      @apply hidden!;
+      @apply hidden;
     }
   }
 }

--- a/packages/design-toolkit/src/components/sidenav/styles.module.css
+++ b/packages/design-toolkit/src/components/sidenav/styles.module.css
@@ -22,14 +22,25 @@
         var(--animation-easing-standard);
     }
 
-    @variant group-push-left/layout {
-      @apply relative;
-      transform: translateX(0);
-    }
-
     @variant closed {
       @apply items-center;
       transform: translateX(calc(-100% + var(--sidenav-width)));
+    }
+
+    @variant group-push-left/layout {
+      @apply relative;
+      transform: translateX(0);
+
+      /*
+       * Push keeps the nav in the layout flow, so the overlay translate can't
+       * reveal a fixed rail. Pin the collapsed width to --sidenav-width so the
+       * collapsed rail matches overlay mode and stays themeable from one
+       * variable. (Declared after `closed` so push's translateX(0) wins and the
+       * relative nav isn't shifted.)
+       */
+      @variant closed {
+        width: var(--sidenav-width);
+      }
     }
   }
 
@@ -74,7 +85,7 @@
   }
 
   .heading {
-    @apply text-body-xs uppercase;
+    @apply text-body-xs;
   }
 
   .item {
@@ -161,7 +172,7 @@
     @apply text-body-s relative;
 
     .heading {
-      @apply flex-1 text-left;
+      @apply text-body-s flex-1 text-left;
     }
 
     .item {
@@ -294,8 +305,15 @@
   }
 
   .transient {
+    /*
+     * `hidden!` is intentional: the `closed` variant wraps its condition in
+     * `:where()` (zero specificity), so this rule ties with `.icon`'s own
+     * `display: block` and loses on source order for icon children (e.g. the
+     * SidenavLink external-link arrow and the SidenavHeader collapse chevron).
+     * `!important` guarantees the hide wins for any child type when collapsed.
+     */
     @variant group-closed/sidenav {
-      @apply hidden;
+      @apply hidden!;
     }
   }
 }


### PR DESCRIPTION
#### Description
- Fixes four `Sidenav` visual bugs observed in JERIC2O, all isolated to the sidenav CSS module. 
- Each is a minimal, targeted change — no component restructuring. 

#### Changes

All in [`sidenav/styles.module.css`](packages/design-toolkit/src/components/sidenav/styles.module.css).

| Change | Bug / why |
| --- | --- |
| `.heading`: drop `uppercase` (`text-body-xs uppercase` → `text-body-xs`) | **Bug 1 — forced UPPERCASE headings.** The standalone `.heading` rule applied `text-transform: uppercase`, and the `text-body-*` utilities never reset it, so it reached *every* heading routed through `HeadingContext` — `SidenavMenu` titles, the popover title, `SidenavAvatar` headings, and `SidenavContent` section headings. Now renders verbatim. |
| `.transient`: `@apply hidden` → `@apply hidden!` | **Bug 2 — collapsed icons leak into the rail.** The `closed` variant wraps its condition in `:where()` (zero specificity), so the hide rule tied with `Icon`'s own `display: block` and lost on source order for icon children. Text hid; icons (the `SidenavLink` external arrow, `SidenavHeader` chevron) didn't. `!important` forces the collapsed-state hide to win for any child type. |
| `.menu .heading`: add `text-body-s` | **Bug 3 — undersized menu title.** The expanded trigger title rendered at `body-xs` (10px) — inherited section-label size — while its own collapsed popover title and sibling nav items are `body-s` (12px). It visibly shrank 12px→10px between states. Now `body-s` everywhere. |
| `.sidenav`: reorder `closed`/`group-push-left/layout`, pin push collapsed width to `var(--sidenav-width)` | **Bug 4 — push-mode rail ignored `--sidenav-width`.** The variable only affected overlay mode (consumed by the collapse transform); push layouts were content-driven, so the collapsed width was inconsistent and not themeable in push. Reordering also fixes a latent transform shift of the relative nav. |

#### Notes
- All headings now render verbatim. The only size variation is intentional: avatar headings 14px, nav text / menu title / popover title 12px, section labels 10px.
- Collapsed rail width is now governed by `--sidenav-width` (default 64px) in **both** overlay and push modes — a behavior change for consumers who set `--sidenav-width` to narrow only their overlay rail; it now applies to push too.
- `!important` on `.transient` is scoped to the collapsed state (the `closed` variant never matches when open), so it can't bleed into the expanded layout.

#### Test plan
- [ ] Storybook → **Components / Sidenav / Title Case And Collapsed Icons** (new story): renders expanded — confirm "The Watch" and avatar headings are title-case, and the menu title matches nav-item size. Collapse via the top-bar toggle → external-link arrow + chevron disappear cleanly, no leftover space.
- [ ] Existing **Default** story: collapse/expand → labels and arrows behave; section headings ("Title A", "External", "Menu") render verbatim.
- [ ] Push vs overlay: in a `DrawerLayout push="left"`, collapsed rail width now honors `--sidenav-width` and matches overlay.
- [ ] `pnpm --filter @accelint/design-toolkit test` → sidenav suite green (incl. new structural test asserting the link arrow carries `transient`).
- [ ] Verification gate: `pnpm build` · `pnpm lint` · `pnpm format` all pass.


