### PR TITLE
fix: notice list bugs

### DIFF
--- a/.changeset/fix-notice-list-queue-handling.md
+++ b/.changeset/fix-notice-list-queue-handling.md
@@ -1,0 +1,10 @@
+---
+'@accelint/design-toolkit': patch
+---
+
+Fix four `NoticeList` bugs:
+
+- "Clear All" no longer throws (`queue.clear` was passed unbound, so `this` was `undefined` and clicking the button raised a TypeError without clearing anything).
+- Per-notice `timeout` and `color` now take precedence over the list-level `defaultTimeout`/`defaultColor`, matching the documented behavior ("defaults for notices without explicit timeout/color"). Previously the list-level values silently overrode every notice.
+- A `NoticeList` without an `id` no longer consumes notices that were explicitly targeted at another list, which previously caused targeted notices to render twice (once in the targeted list and once in every untargeted list).
+- The internal queue subscription is now registered once with proper cleanup. Previously a new subscription was added on every render and never removed, leaking listeners for the life of the page.

--- a/packages/design-toolkit/src/components/notice/list.test.tsx
+++ b/packages/design-toolkit/src/components/notice/list.test.tsx
@@ -11,7 +11,9 @@
  */
 
 import { Broadcast } from '@accelint/bus';
+import { uuid } from '@accelint/core';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NoticeEventTypes } from './events';
 import { NoticeList } from './list';
@@ -51,6 +53,88 @@ describe('NoticeList', () => {
     await waitFor(() => {
       expect(screen.queryByText('Hello 3')).not.toBeInTheDocument();
     });
+  });
+
+  it('should clear all notices when "Clear All" is pressed', async () => {
+    const user = userEvent.setup();
+    setup({ hideClearAll: false });
+
+    act(() => {
+      bus.emit(NoticeEventTypes.queue, { message: 'Notice 1' });
+      bus.emit(NoticeEventTypes.queue, { message: 'Notice 2' });
+    });
+
+    expect(await screen.findByText('Notice 1')).toBeInTheDocument();
+    expect(await screen.findByText('Notice 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Clear All' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Notice 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Notice 2')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should prefer the notice color over defaultColor', async () => {
+    setup({ defaultColor: 'info' });
+
+    act(() => {
+      bus.emit(NoticeEventTypes.queue, {
+        message: 'Critical notice',
+        color: 'critical',
+      });
+    });
+
+    const notice = (await screen.findByText('Critical notice')).closest(
+      '[data-color]',
+    );
+    expect(notice).toHaveAttribute('data-color', 'critical');
+  });
+
+  it('should apply defaultColor when the notice has no color', async () => {
+    setup({ defaultColor: 'advisory' });
+
+    act(() => {
+      bus.emit(NoticeEventTypes.queue, { message: 'Default color notice' });
+    });
+
+    const notice = (await screen.findByText('Default color notice')).closest(
+      '[data-color]',
+    );
+    expect(notice).toHaveAttribute('data-color', 'advisory');
+  });
+
+  it('should ignore notices targeted at another list when it has no id', async () => {
+    setup({});
+
+    act(() => {
+      bus.emit(NoticeEventTypes.queue, {
+        message: 'Targeted elsewhere',
+        target: uuid(),
+      });
+      bus.emit(NoticeEventTypes.queue, { message: 'Untargeted' });
+    });
+
+    expect(await screen.findByText('Untargeted')).toBeInTheDocument();
+    expect(screen.queryByText('Targeted elsewhere')).not.toBeInTheDocument();
+  });
+
+  it('should only receive notices targeted at its own id', async () => {
+    const id = uuid();
+    setup({ id });
+
+    act(() => {
+      bus.emit(NoticeEventTypes.queue, {
+        message: 'Untargeted',
+        target: undefined,
+      });
+      bus.emit(NoticeEventTypes.queue, { message: 'Mine', target: id });
+      bus.emit(NoticeEventTypes.queue, { message: 'Other', target: uuid() });
+    });
+
+    expect(await screen.findByText('Mine')).toBeInTheDocument();
+    expect(screen.queryByText('Untargeted')).not.toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 
   describe('auto-dismiss behavior', () => {

--- a/packages/design-toolkit/src/components/notice/list.tsx
+++ b/packages/design-toolkit/src/components/notice/list.tsx
@@ -111,13 +111,13 @@ export function NoticeList({
   const emitClose = useEmit(NoticeEventTypes.close);
 
   useOn(NoticeEventTypes.queue, (data) => {
-    if ((id && data.payload.target === id) || !id) {
-      const timeout = defaultTimeout ?? data.payload.timeout;
+    if (id ? data.payload.target === id : !data.payload.target) {
+      const timeout = data.payload.timeout ?? defaultTimeout;
       queue.add(
         {
           ...data.payload,
           id: data.payload.id || uuid(),
-          color: defaultColor || data.payload.color,
+          color: data.payload.color || defaultColor,
         },
         {
           timeout,
@@ -146,11 +146,13 @@ export function NoticeList({
     }
   });
 
-  useEffect(() => {
-    queue.subscribe(() => {
-      setHasNotices(queue.visibleToasts.length > 0);
-    });
-  });
+  useEffect(
+    () =>
+      queue.subscribe(() => {
+        setHasNotices(queue.visibleToasts.length > 0);
+      }),
+    [queue],
+  );
 
   const children = (
     <>
@@ -161,7 +163,7 @@ export function NoticeList({
             (className) => className ?? '',
           )}
           variant='outline'
-          onPress={queue.clear}
+          onPress={() => queue.clear()}
         >
           Clear All
         </Button>


### PR DESCRIPTION

  ## Summary

  Fixes four bugs in `NoticeList` (`packages/design-toolkit/src/components/notice/list.tsx`):
  
  1. **"Clear All" crashes and does nothing** — `onPress={queue.clear}` passed the method unbound; react-stately's `ToastQueue.clear()` references `this.queue`, so clicking threw `TypeError: Cannot set properties of undefined (setting
  'queue')` and the list was never cleared.
  2. **List-level defaults override per-notice values** — `defaultTimeout ?? payload.timeout` and `defaultColor || payload.color` gave the *list* precedence, contradicting the documented behavior ("Default color for notices without explicit
  color"). A notice emitted with `color: 'critical'` rendered with the list's `defaultColor` instead.
  3. **Untargeted lists consume targeted notices** — a `NoticeList` without an `id` accepted *every* queue event, including ones explicitly `target`ed at another list, so targeted notices rendered twice when multiple lists were mounted.
  4. **Queue subscription leak** — the `useEffect` had no dependency array and no cleanup, adding a new `queue.subscribe` listener on every render and never removing any.
  
  ## Repro on `main`

  1. `pnpm --filter @accelint/design-toolkit preview` → open Storybook
  2. **Crash:** `Components/NoticeList → Default` → set `hideClearAll: false` in controls → click **Create Notice** twice → click **Clear All** → console shows `TypeError: Cannot set properties of undefined (setting 'queue')`, notices remain
  on screen.
  3. **Precedence:** render a `NoticeList` with `defaultColor='info'` and emit `Notice:queue` with `color: 'critical'` → the notice renders info-colored.
  4. **Targeting:** render two lists — one with an `id`, one without — and emit a notice with `target` set to the first list's id → it appears in **both** lists.
  5. **Leak:** code inspection — `list.tsx` `useEffect` with no deps/cleanup calls `queue.subscribe` every render.

  ## Fix

  - `onPress={() => queue.clear()}`
  - `payload.timeout ?? defaultTimeout` and `payload.color || defaultColor` (per-notice wins; defaults fill gaps)
  - Queue guard: `id ? payload.target === id : !payload.target` — an id-less list only accepts untargeted notices
  - `useEffect(() => queue.subscribe(...), [queue])` — `subscribe()` returns its unsubscribe function, now used as the effect cleanup

  ## Test plan

  - [ ] New regression tests in `list.test.tsx`:
    - Clear All removes all notices without throwing
    - per-notice `color` wins over `defaultColor`
    - `defaultColor` still applies when the notice has no color
    - id-less list ignores notices targeted at another list
    - id'd list receives only its own targeted notices
  - [ ] Existing timeout tests still pass (precedence flip preserves default-only and payload-only behavior)
  - [ ] `pnpm build && pnpm test && pnpm lint && pnpm format`

