### PR TITLE
fix: coordinate field

### DIFF
--- a/.changeset/fix-coordinate-field-controlled-sync.md
+++ b/.changeset/fix-coordinate-field-controlled-sync.md
@@ -1,0 +1,5 @@
+---
+'@accelint/design-toolkit': patch
+---
+
+Fix `CoordinateField` in controlled mode wiping all segments during edits. Emptying one segment (or entering an invalid coordinate) emits `onChange(null)`; when the parent echoed that `null` back into the `value` prop, the field re-synced from it and cleared every segment and any just-set validation error. The field now recognizes echoes of its own `onChange` emissions and leaves in-progress edits and validation errors intact.

--- a/.changeset/fix-geo-ddm-dms-rounding-carry.md
+++ b/.changeset/fix-geo-ddm-dms-rounding-carry.md
@@ -1,0 +1,5 @@
+---
+'@accelint/geo': patch
+---
+
+Fix `formatDegreesDecimalMinutes` and `formatDegreesMinutesSeconds` producing impossible values when rounding rolls over: minutes/seconds that rounded to exactly 60 (e.g. `40.9999995` formatting as `40° 60.0000'`) now carry into the higher unit (`41° 0.0000'`).

--- a/packages/design-toolkit/src/bug-repros.stories.tsx
+++ b/packages/design-toolkit/src/bug-repros.stories.tsx
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Temporary repro stories for candidate bugs tracked in /BUGS.md.
+ * Each story isolates one suspected bug with the expected vs actual behavior
+ * described in its JSDoc. Delete once the bugs are fixed or rejected.
+ */
+
+import { useEmit } from '@accelint/bus/react';
+import { type UniqueId, uuid } from '@accelint/core';
+import { ChevronLeft, Placeholder } from '@accelint/icons';
+import { parseDate, parseZonedDateTime } from '@internationalized/date';
+import { useState } from 'react';
+import { Heading, Text } from 'react-aria-components';
+import { Audio } from './components/audio';
+import { Button } from './components/button';
+import { ColorPicker } from './components/color-picker';
+import { ComboBoxField } from './components/combobox-field';
+import { DateField } from './components/date-field';
+import { Drawer } from './components/drawer';
+import { DrawerLayout } from './components/drawer/layout';
+import { DrawerLayoutMain } from './components/drawer/layout-main';
+import { DrawerMenu } from './components/drawer/menu';
+import { DrawerMenuItem } from './components/drawer/menu-item';
+import { DrawerPanel } from './components/drawer/panel';
+import { DrawerView } from './components/drawer/view';
+import { Icon } from './components/icon';
+import { OptionsItem } from './components/options/item';
+import { OptionsItemContent } from './components/options/item-content';
+import { OptionsItemLabel } from './components/options/item-label';
+import { Sidenav } from './components/sidenav';
+import { SidenavContent } from './components/sidenav/content';
+import { SidenavEventTypes } from './components/sidenav/events';
+import { SidenavItem } from './components/sidenav/item';
+import { SidenavTrigger } from './components/sidenav/trigger';
+import { TimeField } from './components/time-field';
+import { Tree } from './components/tree';
+import { TreeItem } from './components/tree/item';
+import { TreeItemContent } from './components/tree/item-content';
+import { ViewStack } from './components/view-stack';
+import { ViewStackTrigger } from './components/view-stack/trigger';
+import { ViewStackView } from './components/view-stack/view';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type {
+  SidenavCloseEvent,
+  SidenavOpenEvent,
+} from './components/sidenav/types';
+
+const meta: Meta = {
+  title: 'BugRepros',
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * BUGS.md #14 — ViewStack loses batched actions.
+ * Click "Push B", "Push C", then "Back x2".
+ * Expected: View A. Bug: View B (only one pop applies).
+ */
+const vsIds = { stack: uuid(), a: uuid(), b: uuid(), c: uuid() };
+export const ViewStackDoubleBack: Story = {
+  render: () => (
+    <ViewStack id={vsIds.stack} defaultView={vsIds.a}>
+      <ViewStackView id={vsIds.a}>
+        <h1 data-testid='current-view'>View A</h1>
+        <ViewStackTrigger for={vsIds.b}>
+          <Button>Push B</Button>
+        </ViewStackTrigger>
+      </ViewStackView>
+      <ViewStackView id={vsIds.b}>
+        <h1 data-testid='current-view'>View B</h1>
+        <ViewStackTrigger for={vsIds.c}>
+          <Button>Push C</Button>
+        </ViewStackTrigger>
+      </ViewStackView>
+      <ViewStackView id={vsIds.c}>
+        <h1 data-testid='current-view'>View C</h1>
+        <ViewStackTrigger for={['back', 'back']}>
+          <Button>
+            <Icon>
+              <ChevronLeft />
+            </Icon>
+            Back x2
+          </Button>
+        </ViewStackTrigger>
+      </ViewStackView>
+    </ViewStack>
+  ),
+};
+
+/**
+ * BUGS.md #21 — Sidenav open/close guards race against batched state.
+ * Click "Open then Close (same tick)".
+ * Expected: nav ends closed. Bug: close handler reads stale isOpen=false and
+ * skips, so the nav stays open.
+ */
+const raceNavId = uuid();
+function RaceButtons() {
+  const emitOpen = useEmit<SidenavOpenEvent>(SidenavEventTypes.open);
+  const emitClose = useEmit<SidenavCloseEvent>(SidenavEventTypes.close);
+  return (
+    <Button
+      onPress={() => {
+        emitOpen({ id: raceNavId });
+        emitClose({ id: raceNavId });
+      }}
+    >
+      Open then Close (same tick)
+    </Button>
+  );
+}
+export const SidenavOpenCloseRace: Story = {
+  render: () => (
+    <div className='h-[400px]'>
+      <DrawerLayout push='left'>
+        <DrawerLayoutMain>
+          <RaceButtons />
+        </DrawerLayoutMain>
+        <Sidenav id={raceNavId}>
+          <SidenavContent>
+            <SidenavItem textValue='Item'>
+              <Icon>
+                <Placeholder />
+              </Icon>
+              <Text>Item</Text>
+            </SidenavItem>
+          </SidenavContent>
+        </Sidenav>
+      </DrawerLayout>
+    </div>
+  ),
+};
+
+/**
+ * BUGS.md #22 — SidenavTrigger silently no-ops for non-UUID ids.
+ * Click the trigger. Expected: nav toggles. Bug: nothing happens because the
+ * trigger mis-parses the id and emits an undefined event type.
+ */
+const stringNavId = 'main-nav' as UniqueId;
+export const SidenavTriggerStringId: Story = {
+  render: () => (
+    <div className='h-[400px]'>
+      <DrawerLayout push='left'>
+        <DrawerLayoutMain>
+          <SidenavTrigger for={stringNavId}>
+            <Button>Toggle nav (string id)</Button>
+          </SidenavTrigger>
+        </DrawerLayoutMain>
+        <Sidenav id={stringNavId}>
+          <SidenavContent>
+            <SidenavItem textValue='Item'>
+              <Icon>
+                <Placeholder />
+              </Icon>
+              <Text>Item</Text>
+            </SidenavItem>
+          </SidenavContent>
+        </Sidenav>
+      </DrawerLayout>
+    </div>
+  ),
+};
+
+/**
+ * BUGS.md #16 — ComboBoxField `defaultSelectedKey` renders an empty input.
+ * Expected: input shows "Kangaroo" on mount. Bug: input is empty although the
+ * option is selected.
+ */
+const comboItems = [
+  { id: 1, name: 'Red Panda' },
+  { id: 2, name: 'Cat' },
+  { id: 5, name: 'Kangaroo' },
+  { id: 6, name: 'Snake' },
+];
+export const ComboBoxDefaultSelectedKey: Story = {
+  render: () => (
+    <ComboBoxField
+      label='Animal'
+      defaultItems={comboItems}
+      defaultSelectedKey={5}
+    >
+      {(item) => (
+        <OptionsItem key={item.id} textValue={item.name}>
+          <OptionsItemContent>
+            <OptionsItemLabel>{item.name}</OptionsItemLabel>
+          </OptionsItemContent>
+        </OptionsItem>
+      )}
+    </ComboBoxField>
+  ),
+};
+
+/**
+ * BUGS.md #9 — Audio: changing `src` never switches media.
+ * Click "Swap src", then play. Expected: the audio element loads the new URL.
+ * Bug: `currentSrc` stays on the old URL because `src` lives on a `<source>`
+ * child and the element never re-runs resource selection.
+ */
+export const AudioSrcSwap: Story = {
+  render: () => {
+    const [src, setSrc] = useState('/test.mp3?v=1');
+    return (
+      <div className='flex flex-col gap-m'>
+        <Button
+          onPress={() =>
+            setSrc((s) =>
+              s.endsWith('v=1') ? '/test.mp3?v=2' : '/test.mp3?v=1',
+            )
+          }
+        >
+          Swap src
+        </Button>
+        <p data-testid='expected-src'>prop src: {src}</p>
+        <Audio src={src} />
+      </div>
+    );
+  },
+};
+
+/**
+ * BUGS.md #43 — DateField shows description when disabled+small.
+ * Expected: small size hides the description in both fields.
+ * Bug: the disabled small field shows its description.
+ */
+export const DateFieldDisabledSmallDescription: Story = {
+  render: () => (
+    <div className='flex flex-col gap-m'>
+      <DateField
+        label='Enabled small'
+        size='small'
+        description='SHOULD-BE-HIDDEN-1'
+        defaultValue={parseDate('2026-01-15')}
+      />
+      <DateField
+        label='Disabled small'
+        size='small'
+        isDisabled
+        description='SHOULD-BE-HIDDEN-2'
+        defaultValue={parseDate('2026-01-15')}
+      />
+    </div>
+  ),
+};
+
+/**
+ * BUGS.md #45 — TimeField hardcodes a "Z" suffix without UTC conversion.
+ * Value is 12:00 in America/New_York (= 17:00 UTC).
+ * Expected: shows 17:00 with Z (or local time without Z).
+ * Bug: shows 12:00 labeled Z.
+ */
+export const TimeFieldZonedZ: Story = {
+  render: () => (
+    <TimeField
+      label='Zoned time'
+      defaultValue={parseZonedDateTime('2026-01-15T12:00[America/New_York]')}
+    />
+  ),
+};
+
+/**
+ * BUGS.md #44 — ColorPicker drops alpha from RGBA tuples.
+ * Items include [212,35,29,255] and [212,35,29,128] (same RGB, different alpha).
+ * Expected: two visually different swatches. Bug: both render opaque and
+ * collapse to duplicate React keys (console warning).
+ */
+export const ColorPickerAlpha: Story = {
+  render: () => (
+    <ColorPicker
+      items={[
+        [212, 35, 29, 255],
+        [212, 35, 29, 128],
+        [48, 210, 126, 64],
+      ]}
+    />
+  ),
+};
+
+/**
+ * BUGS.md #40 — Tree drops `onSelectionChange` for uncontrolled trees.
+ * Click a row's checkbox. Expected: the counter increments.
+ * Bug: callback is never wired because no `selectedKeys` prop was passed.
+ */
+export const TreeUncontrolledSelection: Story = {
+  render: () => {
+    const [count, setCount] = useState(0);
+    return (
+      <div className='flex flex-col gap-m'>
+        <p data-testid='selection-count'>onSelectionChange calls: {count}</p>
+        <Tree
+          aria-label='Uncontrolled selection'
+          selectionMode='multiple'
+          style={{ width: 400 }}
+          onSelectionChange={() => setCount((c) => c + 1)}
+        >
+          <TreeItem id='one' textValue='one'>
+            <TreeItemContent>Item One</TreeItemContent>
+          </TreeItem>
+          <TreeItem id='two' textValue='two'>
+            <TreeItemContent>Item Two</TreeItemContent>
+          </TreeItem>
+        </Tree>
+      </div>
+    );
+  },
+};
+
+/**
+ * BUGS.md #48 — Drawer open/toggle emits a spurious `onChange(null)`.
+ * Switch between views via the menu. Expected log: "b" then "a" etc.
+ * Bug: every switch logs "null" immediately before the view id.
+ */
+const drawerIds = {
+  drawer: uuid(),
+  a: uuid(),
+  b: uuid(),
+};
+export const DrawerOnChangeNull: Story = {
+  render: () => {
+    const [log, setLog] = useState<string[]>([]);
+    return (
+      <div className='h-[400px]'>
+        <DrawerLayout>
+          <DrawerLayoutMain>
+            <p data-testid='change-log'>
+              onChange log: {log.join(' → ') || '(empty)'}
+            </p>
+          </DrawerLayoutMain>
+          <Drawer
+            id={drawerIds.drawer}
+            placement='left'
+            onChange={(view) =>
+              setLog((l) => [
+                ...l,
+                view === null ? 'null' : view === drawerIds.a ? 'a' : 'b',
+              ])
+            }
+          >
+            <DrawerMenu>
+              <DrawerMenuItem for={drawerIds.a} textValue='A'>
+                <Placeholder />
+              </DrawerMenuItem>
+              <DrawerMenuItem for={drawerIds.b} textValue='B'>
+                <Placeholder />
+              </DrawerMenuItem>
+            </DrawerMenu>
+            <DrawerPanel>
+              <DrawerView id={drawerIds.a}>
+                <Heading>View A</Heading>
+              </DrawerView>
+              <DrawerView id={drawerIds.b}>
+                <Heading>View B</Heading>
+              </DrawerView>
+            </DrawerPanel>
+          </Drawer>
+        </DrawerLayout>
+      </div>
+    );
+  },
+};

--- a/packages/design-toolkit/src/components/coordinate-field/coordinate-field.test.tsx
+++ b/packages/design-toolkit/src/components/coordinate-field/coordinate-field.test.tsx
@@ -676,6 +676,61 @@ describe('CoordinateField', () => {
           expect(errorText).toBeInTheDocument();
         });
       });
+
+      function ControlledCoordinateField() {
+        const [value, setValue] = useState<CoordinateValue | null>(newYorkCity);
+        return (
+          <CoordinateField
+            label='Location'
+            format='dd'
+            value={value}
+            onChange={setValue}
+          />
+        );
+      }
+
+      it('keeps other segments intact when one segment is cleared in controlled mode', async () => {
+        const user = userEvent.setup();
+        render(<ControlledCoordinateField />);
+
+        const latInput = screen.getByLabelText('Latitude') as HTMLInputElement;
+        const lonInput = screen.getByLabelText('Longitude') as HTMLInputElement;
+
+        expect(latInput.value).toBe('40.7128');
+        expect(lonInput.value).toBe('-74.006');
+
+        // Emptying one segment emits onChange(null); the parent echoing null
+        // back must not wipe the other segment.
+        await user.clear(latInput);
+
+        await waitFor(() => {
+          expect(latInput.value).toBe('');
+        });
+        expect(lonInput.value).toBe('-74.006');
+      });
+
+      it('keeps the validation error visible in controlled mode', async () => {
+        const user = userEvent.setup();
+        render(<ControlledCoordinateField />);
+
+        const latInput = screen.getByLabelText('Latitude');
+
+        // 95 is out of range; validation emits onChange(null) — the echo must
+        // not clear the error or the entered segments.
+        await user.clear(latInput);
+        await user.type(latInput, '95');
+
+        await waitFor(() => {
+          expect(
+            screen.getByText('Invalid coordinate value'),
+          ).toBeInTheDocument();
+        });
+
+        expect((latInput as HTMLInputElement).value).toBe('95');
+        expect(
+          screen.getByText('Invalid coordinate value'),
+        ).toBeInTheDocument();
+      });
     });
 
     describe('Component Integration - Uncontrolled Mode', () => {

--- a/packages/design-toolkit/src/hooks/coordinate-field/use-coordinate-field-state.ts
+++ b/packages/design-toolkit/src/hooks/coordinate-field/use-coordinate-field-state.ts
@@ -141,6 +141,10 @@ export function useCoordinateFieldState({
   );
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Last value emitted via onChange; `undefined` means nothing emitted yet.
+  const lastEmittedValueRef = useRef<CoordinateValue | null | undefined>(
+    undefined,
+  );
 
   const currentValue = value !== undefined ? value : internalValue;
 
@@ -152,6 +156,7 @@ export function useCoordinateFieldState({
   };
 
   const handleChange = (newValue: CoordinateValue | null) => {
+    lastEmittedValueRef.current = newValue;
     if (value === undefined) {
       setInternalValue(newValue);
     }
@@ -207,7 +212,27 @@ export function useCoordinateFieldState({
   }, [format, value, internalValue, convertValueToSegmentsOrClear]);
 
   useEffect(() => {
-    if (value !== undefined) {
+    if (value === undefined) {
+      return;
+    }
+
+    /*
+     * Skip re-syncing when the controlled `value` is just the echo of our own
+     * onChange (the parent storing what we emitted). Without this guard, the
+     * `handleChange(null)` fired for an in-progress edit (one segment emptied,
+     * or an invalid entry) comes straight back and wipes every segment and any
+     * validation error that was just set.
+     */
+    const lastEmitted = lastEmittedValueRef.current;
+    const isEchoOfEmit =
+      lastEmitted !== undefined &&
+      (value === lastEmitted ||
+        (value !== null &&
+          lastEmitted !== null &&
+          value.lat === lastEmitted.lat &&
+          value.lon === lastEmitted.lon));
+
+    if (!isEchoOfEmit) {
       convertValueToSegmentsOrClear(value);
     }
   }, [value, convertValueToSegmentsOrClear]);

--- a/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.test.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDegreesDecimalMinutes } from './formatter';
+
+describe('formatDegreesDecimalMinutes', () => {
+  it('formats typical coordinates', () => {
+    expect(formatDegreesDecimalMinutes([37.7749, -122.4194])).toBe(
+      "37° 46.4940', 122° 25.1640'",
+    );
+  });
+
+  it('formats whole-degree values with zero minutes', () => {
+    expect(formatDegreesDecimalMinutes([45, -122])).toBe(
+      "45° 0.0000', 122° 0.0000'",
+    );
+  });
+
+  it('carries into degrees when minutes round to 60', () => {
+    // 40.9999995 -> minutes 59.99997 -> rounds to 60.0000 -> must carry
+    expect(formatDegreesDecimalMinutes([40.9999995, -74.006])).toBe(
+      "41° 0.0000', 74° 0.3600'",
+    );
+  });
+
+  it('carries correctly at the pole/antimeridian boundary', () => {
+    expect(formatDegreesDecimalMinutes([89.99999999, 179.99999999])).toBe(
+      "90° 0.0000', 180° 0.0000'",
+    );
+  });
+});

--- a/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.ts
@@ -31,10 +31,17 @@ import { createFormatter } from '../internal/format';
  * ```
  */
 const toDegreesDecimalMinutes = (num: number): string => {
-  const degrees = Math.floor(Math.abs(num));
-  const minutes = ((Math.abs(num) - degrees) * 60).toFixed(4);
+  let degrees = Math.floor(Math.abs(num));
+  let minutes = Number(((Math.abs(num) - degrees) * 60).toFixed(4));
 
-  return `${degrees}° ${minutes}'`;
+  // Rounding can produce 60 minutes (e.g. 40.9999995 -> 40° 60.0000');
+  // carry into degrees so the output stays a valid coordinate.
+  if (minutes >= 60) {
+    degrees += 1;
+    minutes = 0;
+  }
+
+  return `${degrees}° ${minutes.toFixed(4)}'`;
 };
 
 /**

--- a/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-decimal-minutes/formatter.ts
@@ -36,10 +36,8 @@ const toDegreesDecimalMinutes = (num: number): string => {
 
   // Rounding can produce 60 minutes (e.g. 40.9999995 -> 40° 60.0000');
   // carry into degrees so the output stays a valid coordinate.
-  if (minutes >= 60) {
-    degrees += 1;
-    minutes = 0;
-  }
+  degrees += Math.floor(minutes / 60);
+  minutes %= 60;
 
   return `${degrees}° ${minutes.toFixed(4)}'`;
 };

--- a/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.test.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDegreesMinutesSeconds } from './formatter';
+
+describe('formatDegreesMinutesSeconds', () => {
+  it('formats typical coordinates', () => {
+    expect(formatDegreesMinutesSeconds([37.7749, -122.4194])).toBe(
+      "37° 46' 29.64″, 122° 25' 9.84″",
+    );
+  });
+
+  it('carries into minutes when seconds round to 60', () => {
+    // 40 + (30 * 60 + 59.999) / 3600 -> seconds 59.999 -> rounds to 60.00
+    const value = 40 + (30 * 60 + 59.999) / 3600;
+    expect(formatDegreesMinutesSeconds([value, 0])).toBe(
+      "40° 31' 0.00″, 0° 0' 0.00″",
+    );
+  });
+
+  it('carries through minutes into degrees when both roll over', () => {
+    // 40.99999999 -> 40° 59' 60.00″ without carrying -> must become 41° 0' 0.00″
+    expect(formatDegreesMinutesSeconds([40.99999999, -74.006])).toBe(
+      "41° 0' 0.00″, 74° 0' 21.60″",
+    );
+  });
+
+  it('carries correctly at the pole boundary', () => {
+    expect(formatDegreesMinutesSeconds([89.99999999, 179.99999999])).toBe(
+      "90° 0' 0.00″, 180° 0' 0.00″",
+    );
+  });
+});

--- a/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.ts
@@ -31,12 +31,23 @@ import { createFormatter } from '../internal/format';
  * ```
  */
 const toDegreesMinutesSeconds = (num: number): string => {
-  const degrees = Math.floor(Math.abs(num));
+  let degrees = Math.floor(Math.abs(num));
   const minutesFull = (Math.abs(num) - degrees) * 60;
-  const minutes = Math.floor(minutesFull);
-  const seconds = ((minutesFull - minutes) * 60).toFixed(2);
+  let minutes = Math.floor(minutesFull);
+  let seconds = Number(((minutesFull - minutes) * 60).toFixed(2));
 
-  return `${degrees}° ${minutes}' ${seconds}″`;
+  // Rounding can produce 60 seconds (e.g. 40.9999999 -> 40° 59' 60.00″);
+  // carry into minutes (and degrees) so the output stays a valid coordinate.
+  if (seconds >= 60) {
+    minutes += 1;
+    seconds = 0;
+  }
+  if (minutes >= 60) {
+    degrees += 1;
+    minutes = 0;
+  }
+
+  return `${degrees}° ${minutes}' ${seconds.toFixed(2)}″`;
 };
 
 /**

--- a/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.ts
+++ b/packages/geo/src/coordinates/latlon/degrees-minutes-seconds/formatter.ts
@@ -38,14 +38,10 @@ const toDegreesMinutesSeconds = (num: number): string => {
 
   // Rounding can produce 60 seconds (e.g. 40.9999999 -> 40° 59' 60.00″);
   // carry into minutes (and degrees) so the output stays a valid coordinate.
-  if (seconds >= 60) {
-    minutes += 1;
-    seconds = 0;
-  }
-  if (minutes >= 60) {
-    degrees += 1;
-    minutes = 0;
-  }
+  minutes += Math.floor(seconds / 60);
+  seconds %= 60;
+  degrees += Math.floor(minutes / 60);
+  minutes %= 60;
 
   return `${degrees}° ${minutes}' ${seconds.toFixed(2)}″`;
 };


### PR DESCRIPTION
  ## Summary

  Two `CoordinateField` correctness fixes:

  1. **Controlled mode wipes the whole field mid-edit** (`@accelint/design-toolkit`) — the hook's value-sync effect re-ran on every `value` prop change. Emptying one segment (or typing an
  invalid coordinate) emits `onChange(null)`; a controlled parent echoes that `null` straight back, and the effect rebuilt **all** segments from it — clearing the longitude when you
  backspaced the latitude, and erasing the "Invalid coordinate value" error one render after it appeared.
  2. **DDM/DMS formatting produces impossible "60" minutes/seconds** (`@accelint/geo`) — `toFixed` rounding in `formatDegreesDecimalMinutes`/`formatDegreesMinutesSeconds` could roll
  minutes/seconds to exactly 60 with no carry, so `40.9999995` formatted as `40° 60.0000'` instead of `41° 0.0000'`. The field then flagged its own output as invalid on blur.

  ## Repro on `main`

  1. `pnpm --filter @accelint/design-toolkit preview` → open Storybook
  2. **Controlled wipe:** `Components/CoordinateField → With Initial Value` → click the latitude segment → press Backspace → **both** latitude and longitude clear (`["40.7128","-74.006"]`
  → `["",""]`). Or type `95` as latitude → error flashes, then the whole field empties.
  3. **60-minutes:** render `<CoordinateField format='ddm' value={{ lat: 40.9999995, lon: -74.006 }} />` → segments read `40° 60' N` — an impossible coordinate. Same root cause in
  `@accelint/geo`: `formatDegreesDecimalMinutes([40.9999995, -74.006])` → `"40° 60.0000', 74° 0.3600'"`.

  ## Fix

  - **Echo guard** (`use-coordinate-field-state.ts`): the hook records the last value it emitted via `onChange` (`lastEmittedValueRef`). The value-sync effect now skips re-syncing when the
   incoming controlled `value` is that same echo (compared by `lat`/`lon`, with `null === null`), so in-progress edits and validation errors survive. Genuinely new external values still
  re-sync as before.
  - **Rounding carry** (`geo` formatters): after rounding, `minutes >= 60` carries into degrees (DDM) and `seconds >= 60` carries into minutes, then minutes into degrees (DMS). Output
  precision/format unchanged.

  ## Test plan

  - [ ] New `formatter.test.ts` for DDM + DMS in `@accelint/geo`: typical values unchanged, carry at `40.9999995`, double carry (`59' 60.00″` → `+1°`), pole/antimeridian boundary
  (`89.99999999` → `90° 0'`)
  - [ ] New controlled-mode regression tests in `coordinate-field.test.tsx`: clearing one segment leaves the other intact; the validation error stays visible (and segments keep the typed
  text) after an invalid entry
  - [ ] Existing coordinate-field + geo parser suites still pass
  - [ ] `pnpm build && pnpm test && pnpm lint && pnpm format`
