### PR TITLE
fix: pagination bug

### DIFF
--- a/.changeset/fix-pagination-out-of-range-clamp.md
+++ b/.changeset/fix-pagination-out-of-range-clamp.md
@@ -1,0 +1,5 @@
+---
+'@accelint/design-toolkit': patch
+---
+
+Fix `Pagination` becoming permanently unusable when `total` shrinks below the current page (e.g. after a refetch or filter change). Out-of-range state unmounted every page button and disabled both Prev and Next with no way to recover. The current page now clamps to `total`, navigation stays enabled, and `onChange` is notified of the corrected page.

--- a/packages/design-toolkit/src/components/pagination/index.tsx
+++ b/packages/design-toolkit/src/components/pagination/index.tsx
@@ -14,6 +14,7 @@
 
 import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
+import { useEffect } from 'react';
 import { useControlledState } from 'react-stately/useControlledState';
 import { PaginationContext } from './context';
 import { PaginationNext } from './next';
@@ -55,12 +56,27 @@ export function Pagination({
 }: PaginationProps) {
   const [page, setPage] = useControlledState(value, defaultValue, onChange);
 
+  /*
+   * Clamp to `total` so a shrinking page count (refetch, filter change) can't
+   * strand the page out of range — out-of-range state disabled Prev AND Next
+   * and unmounted every page button, leaving no way to recover.
+   */
+  const effectivePage = total > 0 ? Math.min(page, total) : page;
+
+  useEffect(() => {
+    if (total > 0 && page > total) {
+      setPage(total);
+    }
+  }, [total, page, setPage]);
+
   return (
-    <PaginationContext.Provider value={{ page, total, isLoading, setPage }}>
+    <PaginationContext.Provider
+      value={{ page: effectivePage, total, isLoading, setPage }}
+    >
       <nav
         {...rest}
         className={clsx(styles.container, classNames?.container)}
-        aria-label={`Page ${page} of ${total}`}
+        aria-label={`Page ${effectivePage} of ${total}`}
       >
         {children || (
           <>

--- a/packages/design-toolkit/src/components/pagination/pagination.test.tsx
+++ b/packages/design-toolkit/src/components/pagination/pagination.test.tsx
@@ -77,10 +77,33 @@ describe('Pagination', () => {
     expect(screen.getByRole('navigation').children).toHaveLength(2);
   });
 
-  it('should show empty component on currentPage > pageCount', () => {
-    setup({ value: 6, total: 5, onChange: vi.fn() });
+  it('should clamp to the last page when currentPage exceeds pageCount', () => {
+    const { onChange } = setup({ value: 6, total: 5, onChange: vi.fn() });
 
-    expect(screen.getByRole('navigation').children).toHaveLength(2);
+    // Clamped to page 5: the full pagination renders and stays usable
+    expect(screen.getByRole('navigation').children).toHaveLength(7);
+    expect(screen.getByRole('button', { name: '5' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByLabelText('Previous page')).not.toBeDisabled();
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it('should recover when total shrinks below the current page', () => {
+    const { rerender } = render(<Pagination defaultValue={4} total={4} />);
+
+    expect(screen.getByRole('button', { name: '4' })).toBeInTheDocument();
+
+    rerender(<Pagination defaultValue={4} total={2} />);
+
+    // Previously this stranded the page out of range: every page button
+    // unmounted and Prev AND Next disabled with no way to recover.
+    expect(screen.getByRole('button', { name: '2' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByLabelText('Previous page')).not.toBeDisabled();
   });
 
   describe('getPaginationRange()', () => {


### PR DESCRIPTION
  ## Summary

  Fixes `Pagination` permanently bricking itself when the current page ends up beyond `total` — a state any consumer hits when a refetch or filter change shrinks the page count while the
  user is on a later page.

  When `page > total`:
  - `getPaginationRange` returned `{0, 0}`, unmounting **every** page button
  - `isNavigationDisabled` returned `true`, disabling **Prev as well as Next**

  …leaving no control to recover. In uncontrolled mode the component was permanently dead.

  ## Repro on `main`

  1. `pnpm --filter @accelint/design-toolkit preview` → Storybook → `Components/Pagination → Default` (uncontrolled, `total: 4`)
  2. Click page **4**
  3. Change the `total` control to **2**
  4. All page buttons disappear; Previous **and** Next are both disabled — nothing is clickable.

  ## Fix

  `pagination/index.tsx` — the provider now derives an `effectivePage = Math.min(page, total)` (when `total > 0`) for everything downstream (page buttons, Prev/Next disabling,
  `aria-label`), and an effect writes the clamped value back through `setPage` so `onChange` consumers are notified of the correction.

  **Behavior change (intentional, this is the bug):** controlled `value > total` previously rendered an empty, fully-disabled nav; it now renders clamped to the last page and calls
  `onChange(total)` once. The existing test asserting the empty render was updated accordingly. `value < 1` and `total = 0` behavior is unchanged.

  ## Test plan

  - [ ] Updated test: `value: 6, total: 5` → full nav renders, page 5 is `aria-current`, Prev enabled, `onChange(5)` fired
  - [ ] New regression test: uncontrolled at page 4, rerender with `total: 2` → clamps to page 2, navigation usable
  - [ ] Existing pagination suite (boundaries, single page, `total: 0`, `value: -3`) still passes
  - [ ] `pnpm build && pnpm test && pnpm lint && pnpm format`
