### PR TITLE
fix: move radashi to externals list

### DIFF
--- a/.changeset/map-toolkit-external-radashi.md
+++ b/.changeset/map-toolkit-external-radashi.md
@@ -1,0 +1,5 @@
+---
+'@accelint/map-toolkit': patch
+---
+
+Mark `radashi` as external in the build instead of bundling it. With `unbundle` on, the optional `radashi` dependency was inlined and its import rewritten to a `node_modules/.pnpm/radashi@…/…` store path. Bundlers that reject pnpm store paths (e.g. Turbopack) failed to resolve every `@accelint/map-toolkit` subpath with an "Invalid symlink" error in consuming apps. `radashi` is already an `optionalDependency`, so emitting a bare `radashi` specifier resolves cleanly from the consumer's `node_modules`.

--- a/packages/map-toolkit/tsdown.config.ts
+++ b/packages/map-toolkit/tsdown.config.ts
@@ -51,6 +51,11 @@ export default defineConfig({
     '@ngageoint/gars-js',
     '@ngageoint/grid-js',
     '@ngageoint/mgrs-js',
+    // `radashi` is an optionalDependency, so keep it external instead of letting
+    // `unbundle` inline it. Bundling rewrites the import to a `node_modules/.pnpm/…`
+    // store path, which some bundlers (e.g. Turbopack) reject as an invalid
+    // symlink; a bare `radashi` specifier resolves cleanly from the consumer.
+    'radashi',
     '@turf/helpers',
     '@turf/turf',
     '@vis.gl/react-maplibre',


### PR DESCRIPTION
Closes issue found in neo-for-iamd where the build without this fix to the config would result in a symlink error for map-toolkit

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [x] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

you can build the maptoolkit locally and compare the dist files. the one on this branch should not include .pnpm and radashi should not be bundled with map-toolkit

you could do this in the terminal as one option of verifying that.
```
cd packages/map-toolkit && pnpm build
# Expect: dist/node_modules/.pnpm/  is GONE
ls dist/node_modules 2>/dev/null && echo "BUG: still bundled" || echo "FIXED: radashi not bundled"
# Expect: the radashi import is a bare specifier
grep radashi dist/deckgl/extensions/coffin-corner/coffin-corner-extension.js
# should print:  import { isSetEqual } from "radashi";
```

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [x] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
