### PR TITLE
Feat/update status options

### DIFF
--- a/.changeset/perky-grapes-ask.md
+++ b/.changeset/perky-grapes-ask.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": minor
+---
+
+Adds new status options to StatusIndicator component: unknown and pending. Also adds a convenience option for adding a label.

--- a/packages/design-toolkit/src/components/status-indicator/index.tsx
+++ b/packages/design-toolkit/src/components/status-indicator/index.tsx
@@ -15,30 +15,35 @@ import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
 import styles from './styles.module.css';
 import type { StatusIndicatorProps } from './types';
+import { Label } from '../label';
 
 /**
  * StatusIndicator - A component for displaying connection/service status information
  *
  * Provides a purely presentational component to allow users to display the status of something.
- * Only 'good,' 'degraded,', and 'poor' statuses are being supported.
+ * Supports 'good', 'degraded', 'poor', 'unknown', and 'pending' statuses.
  *
  * @param props - {@link StatusIndicatorProps}
- * @param props.status - The status to display (good, degraded, or poor)
+ * @param props.status - The status to display
+ * @param props.textValue - Optional label to display next to the status icon
  * @returns The rendered StatusIndicator component.
  *
  * @example
  * ```tsx
  * // Basic status indicator
  * <StatusIndicator status="good" />
+ *
+ * // With label
+ * <StatusIndicator status="degraded" textValue="Connection unstable" />
  * ```
  */
-
 export function StatusIndicator({
   className,
   status = 'good',
+  textValue,
   ...rest
 }: StatusIndicatorProps) {
-  return (
+  const statusIcon = (
     <span
       {...rest}
       className={clsx(styles.icon, className)}
@@ -46,4 +51,15 @@ export function StatusIndicator({
       data-testid={`status-${status}-icon`}
     />
   );
+
+  if (textValue) {
+    return (
+      <div className='flex items-center gap-s'>
+        <div className='min-w-m flex justify-center'>{statusIcon}</div>
+        <Label>{textValue}</Label>
+      </div>
+    );
+  }
+
+  return statusIcon;
 }

--- a/packages/design-toolkit/src/components/status-indicator/index.tsx
+++ b/packages/design-toolkit/src/components/status-indicator/index.tsx
@@ -15,7 +15,7 @@ import 'client-only';
 import { clsx } from '@accelint/design-foundation/lib/utils';
 import styles from './styles.module.css';
 import type { StatusIndicatorProps } from './types';
-import { Label } from '../label';
+import { Label } from 'react-aria-components/Label';
 
 /**
  * StatusIndicator - A component for displaying connection/service status information

--- a/packages/design-toolkit/src/components/status-indicator/index.tsx
+++ b/packages/design-toolkit/src/components/status-indicator/index.tsx
@@ -55,7 +55,7 @@ export function StatusIndicator({
   if (textValue) {
     return (
       <div className='flex items-center gap-s'>
-        <div className='min-w-m flex justify-center'>{statusIcon}</div>
+        <div className='flex min-w-m justify-center'>{statusIcon}</div>
         <Label>{textValue}</Label>
       </div>
     );

--- a/packages/design-toolkit/src/components/status-indicator/status-indicator.docs.mdx
+++ b/packages/design-toolkit/src/components/status-indicator/status-indicator.docs.mdx
@@ -10,7 +10,7 @@ The `StatusIndicator` component renders a small, non-interactive visual indicato
 
 It is composed of a single element:
 
-- **StatusIndicator** — a `span` that renders a status “dot” via styling and a `data-status` attribute.
+- **StatusIndicator** — a `span` that renders a status “dot” via styling and a `data-status` attribute. To pair it with text, you can either compose with the `StatusIndicator` component or use the `textValue` prop.
 
 ## Example usage
 
@@ -24,11 +24,20 @@ It is composed of a single element:
 // Poor status
 <StatusIndicator status="poor" />
 
+// Pending status
+<StatusIndicator status="pending" />
+
+// Unknown status
+<StatusIndicator status="unknown" />
+
 // With custom styling hook
 <StatusIndicator
   status="good"
   className="ring-2 ring-offset-2"
 />
+
+// With label
+<StatusIndicator status="good" textValue="Status Normal"/>
 ```
 
 ## Statuses
@@ -40,19 +49,23 @@ degraded — partial issues / warning state
 
 poor — unhealthy / critical state
 
+pending - waiting for information
+
+unknown - self-explanatory
+
 Note: The visual treatment for each status is defined in the component’s CSS module (styles.module.css) using data-status variants.
 
 <Canvas of={StatusIndicatorStories.Demo} />
 
 ## Props
 
-| Prop        | Type                             | Default  | Description                                                 |
-| ----------- | -------------------------------- | -------- | ----------------------------------------------------------- |
-| `status`    | `'good' \| 'degraded' \| 'poor'` | `'good'` | The status to display; applied as `data-status` for styling |
-| `className` | `string`                         | —        | Custom CSS class for the status indicator                   |
+| Prop        | Type                                                       | Default     | Description                                                 |
+| ----------- | ---------------------------------------------------------- | ----------- | ----------------------------------------------------------- |
+| `status`    | `'good' \| 'degraded' \| 'poor' \| 'pending' \| 'unknown'` | `'good'`    | The status to display; applied as `data-status` for styling |
+| `textValue` | `string`                                                   | `undefined` | Displays a label if it is present                           |
+| `className` | `string`                                                   | —           | Custom CSS class for the status indicator                   |
 
 Extends standard HTML `<span>` props.
-
 
 ## Accessibility
 StatusIndicator is presentational and does not provide its own accessible name. If the status meaning must be announced to assistive tech, wrap or annotate it in the parent context, for example:

--- a/packages/design-toolkit/src/components/status-indicator/status-indicator.stories.tsx
+++ b/packages/design-toolkit/src/components/status-indicator/status-indicator.stories.tsx
@@ -53,6 +53,8 @@ const STATUSES: StatusIndicatorProps['status'][] = [
   'good',
   'degraded',
   'poor',
+  'pending',
+  'unknown',
 ] as const;
 
 // made this story for documentation only; hence the !dev tag
@@ -86,9 +88,12 @@ export const Default: Story = {
 
 export const WithLabel: Story = {
   render: () => (
-    <div className='flex items-center gap-s'>
-      <StatusIndicator status='good' />
-      <Label>System online</Label>
+    <div className='flex flex-col gap-s'>
+      <StatusIndicator status='good' textValue='System online' />
+      <StatusIndicator status='degraded' textValue='Degraded connectivity' />
+      <StatusIndicator status='poor' textValue='Poor connectivity' />
+      <StatusIndicator status='pending' textValue='Standby' />
+      <StatusIndicator status='unknown' textValue='Off' />
     </div>
   ),
 };

--- a/packages/design-toolkit/src/components/status-indicator/status-indicator.test.tsx
+++ b/packages/design-toolkit/src/components/status-indicator/status-indicator.test.tsx
@@ -31,6 +31,8 @@ const VALID_STATUSES: StatusIndicatorProps['status'][] = [
   'good',
   'degraded',
   'poor',
+  'pending',
+  'unknown',
 ] as const;
 
 describe('StatusIndicator', () => {
@@ -48,5 +50,22 @@ describe('StatusIndicator', () => {
 
     const indicator = screen.getByTestId('status-good-icon');
     expect(indicator).toHaveClass(customClass);
+  });
+
+  it('should render textValue when provided', () => {
+    const textValue = 'Connection stable';
+    setup({ status: 'good', textValue });
+
+    const label = screen.getByText(textValue);
+    expect(label).toBeInTheDocument();
+  });
+
+  it('should not render textValue wrapper when textValue is not provided', () => {
+    setup({ status: 'good' });
+
+    const label = screen.queryByRole('label');
+
+    expect(label).not.toBeInTheDocument();
+    expect(label).toBeNull();
   });
 });

--- a/packages/design-toolkit/src/components/status-indicator/styles.module.css
+++ b/packages/design-toolkit/src/components/status-indicator/styles.module.css
@@ -30,5 +30,13 @@
       /* isosceles triangle */
       clip-path: polygon(0% 0%, 100% 0%, 50% 100%);
     }
+
+    @variant data-[status=pending] {
+      @apply outline-accent-primary-bold size-s rounded-full bg-transparent outline-2;
+    }
+
+    @variant data-[status=unknown] {
+      @apply size-s rounded-full bg-(--fg-info-bold);
+    }
   }
 }

--- a/packages/design-toolkit/src/components/status-indicator/types.ts
+++ b/packages/design-toolkit/src/components/status-indicator/types.ts
@@ -13,5 +13,6 @@
 import type { ComponentPropsWithRef } from 'react';
 
 export type StatusIndicatorProps = ComponentPropsWithRef<'span'> & {
-  status?: 'good' | 'degraded' | 'poor';
+  status?: 'good' | 'degraded' | 'poor' | 'pending' | 'unknown';
+  textValue?: string;
 };


### PR DESCRIPTION
Closes https://gitlab.accelint.dev/core-ux/standard-toolkit/-/issues/106

Adds two new statuses, pending and unknown. I also added a `textValue` prop that can be used to add a label. Not required, of course, but just to make adding a label simpler without changing just the raw status indicator.

https://design-toolkit-git-feat-update-status-options-accelint.vercel.app/?path=/story/components-statusindicator--with-label

<img width="231" height="189" alt="CleanShot 2026-06-24 at 08 09 12" src="https://github.com/user-attachments/assets/1e549b33-2a21-4bb4-92c4-d9d68618f8ce" />

FWIW the figma file has different names for these and, really, a little better. but changing the enum values of the status indicator was a breaking change and doesn't really improve the customer experience, so I just left it was it is.

## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [ ] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [ ] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [ ] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
