### PR TITLE
Feat/playwright map testing

### DIFF
--- a/apps/next/README.md
+++ b/apps/next/README.md
@@ -1,31 +1,99 @@
-# DevTK Nextjs Test Bed
+# StandardTK Nextjs Test Bed
 
-1. Install dependencies:
+This is a Next.js application that lives alongside the Standard Toolkit packages and consumes them as a real application would. Its purpose is to develop and validate library features in a production-like environment. After building the workspace packages, your local library changes are available here to exercise directly in app context.
+
+Use it two ways:
+
+- **As a development environment** for iterating on library features against a real app, including behavior that unit tests and Storybook don't surface — server-side rendering, routing, and full-page composition.
+- **As a home for durable tests** that need an application context, such as the component pages and the memory leak suite documented below.
+
+## Setup
+
+Run these once from the **repo root** before working in the test bed. Because the
+app consumes the toolkit packages as workspace dependencies, the packages must be
+built before the app can resolve them.
+
+1. Install all workspace dependencies:
 
 ```sh
 pnpm install
 ```
 
-2. Build workspace packages:
+2. Build the toolkit packages so the app can consume them:
 
 ```sh
 pnpm run build
 ```
 
-3. Start the dev server:
+> Re-run `pnpm run build` whenever you change a library package and want those
+> changes reflected here.
+
+## Running the App
+
+These commands are scoped to this app with `--filter=@apps/next`, so you can run
+them from anywhere in the repo. Note that if you don't see the library changes, you can kill node modules and re-install. It can also be a useful way to understand what is exported from the library and whether your feature has the API that you want it to have.
 
 ```sh
 pnpm --filter=@apps/next run dev
 ```
 
-4. Build the application:
+  The app is served at [http://localhost:3000](http://localhost:3000).
+
+- **Build** a production bundle of the app:
 
 ```sh
 pnpm --filter=@apps/next run build
 ```
 
-5. Run production bundle:
+- **Serve** the production build locally (run `build` first):
 
 ```sh
 pnpm --filter=@apps/next run start
 ```
+
+## Integration Tests (Playwright)
+
+The integration tests run with [Playwright](https://playwright.dev). Installing
+dependencies with `pnpm install` does **not** download the browser binaries
+Playwright needs — those are cached globally on your machine and must be
+installed once per machine.
+
+1. Download the browser binary (Chromium is the only browser configured):
+
+```sh
+pnpm --filter=@apps/next exec playwright install chromium
+```
+
+> The `--filter=@apps/next` flag is required: the `playwright` binary is only
+> linked in `apps/next/node_modules`, so running `pnpm exec playwright` from the
+> repo root fails with `command not found`.
+
+2. Run the tests:
+
+```sh
+pnpm --filter=@apps/next run test:integration
+```
+
+3. Run the tests in headed mode (watch the browser drive the UI):
+
+```sh
+pnpm --filter=@apps/next run test:integration:headed
+```
+
+## Visual Regression Tests
+
+Visual regression tests capture screenshots of components and compare them
+against baseline images to detect unintended visual changes. Baselines are
+captured on Linux in CI for consistency, so these tests run in CI only.
+
+See [`src/visual-regression/README.md`](./src/visual-regression/README.md) for
+details on structure, writing tests, and updating baselines.
+
+## Memory Leak Tests
+
+Memory leak tests use [MemLab](https://facebook.github.io/memlab/) and Playwright
+to detect detached DOM nodes and leaked memory in components by repeatedly
+mounting and unmounting them, then analyzing heap snapshots against baselines.
+
+See [`src/memlab/README.md`](./src/memlab/README.md) for details on running,
+configuring thresholds, and updating baselines.

--- a/apps/next/app/map/symbol-layer/page.tsx
+++ b/apps/next/app/map/symbol-layer/page.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use client';
+
+import '@accelint/map-toolkit/deckgl/symbol-layer/fiber';
+import { uuid } from '@accelint/core';
+import { BaseMap } from '@accelint/map-toolkit/deckgl';
+import { DEFAULT_VIEW_STATE } from '@accelint/map-toolkit/shared/constants';
+import { MapTestBridge } from '~/features/map/test-bridge';
+import type { PickingInfo } from '@deck.gl/core';
+
+// NOTE: `<symbolLayer>` is registered at runtime by the fiber side-effect import
+// above, but its JSX type augmentation doesn't reach this app's global `JSX`
+// namespace, so tsc flags it. Harmless — `next build` ignores type errors.
+// TODO: type `<symbolLayer>` properly.
+
+const mapId = uuid();
+
+/**
+ * Symbols spread across the map, plus one pinned to the initial view center
+ * (`id: 'center'`) so an integration test can click canvas-center and reliably
+ * hit a known feature without doing any lng/lat → screen projection.
+ */
+const SYMBOL_DATA = [
+  {
+    id: 'center',
+    sidc: '130301000011010100000000000000',
+    position: [DEFAULT_VIEW_STATE.longitude, DEFAULT_VIEW_STATE.latitude],
+  },
+  {
+    id: 1,
+    sidc: '130340000015011300000000000000',
+    position: [-117.957499, 34.236734],
+  },
+  {
+    id: 2,
+    sidc: '130540000014080000000000000000',
+    position: [-122.32659, 44.91817],
+  },
+  {
+    id: 3,
+    sidc: '130610000016480000000000000000',
+    position: [-95.73333, 30.996191],
+  },
+];
+
+export default function Page() {
+  return (
+    <>
+      <BaseMap
+        className='fixed inset-0'
+        id={mapId}
+        initialViewState={DEFAULT_VIEW_STATE}
+        onClick={(info: PickingInfo) => {
+          if (!window.__mapTest) {
+            window.__mapTest = {
+              ready: false,
+              viewport: null,
+              viewportCount: 0,
+              lastPick: null,
+            };
+          }
+
+          window.__mapTest.lastPick = {
+            layerId: info.layer?.id ?? null,
+            objectId: (info.object as { id?: string | number })?.id ?? null,
+            index: info.index,
+          };
+        }}
+      >
+        <symbolLayer
+          id='symbols'
+          data={SYMBOL_DATA}
+          defaultSymbolOptions={{ colorMode: 'Dark', square: true }}
+          pickable
+        />
+      </BaseMap>
+      <MapTestBridge />
+    </>
+  );
+}

--- a/apps/next/app/map/symbol-layer/page.tsx
+++ b/apps/next/app/map/symbol-layer/page.tsx
@@ -13,18 +13,8 @@
 'use client';
 
 import '@accelint/map-toolkit/deckgl/symbol-layer/fiber';
-import { uuid } from '@accelint/core';
-import { BaseMap } from '@accelint/map-toolkit/deckgl';
 import { DEFAULT_VIEW_STATE } from '@accelint/map-toolkit/shared/constants';
-import { MapTestBridge } from '~/features/map/test-bridge';
-import type { PickingInfo } from '@deck.gl/core';
-
-// NOTE: `<symbolLayer>` is registered at runtime by the fiber side-effect import
-// above, but its JSX type augmentation doesn't reach this app's global `JSX`
-// namespace, so tsc flags it. Harmless — `next build` ignores type errors.
-// TODO: type `<symbolLayer>` properly.
-
-const mapId = uuid();
+import { MapExample } from '~/features/map';
 
 /**
  * Symbols spread across the map, plus one pinned to the initial view center
@@ -56,36 +46,13 @@ const SYMBOL_DATA = [
 
 export default function Page() {
   return (
-    <>
-      <BaseMap
-        className='fixed inset-0'
-        id={mapId}
-        initialViewState={DEFAULT_VIEW_STATE}
-        onClick={(info: PickingInfo) => {
-          if (!window.__mapTest) {
-            window.__mapTest = {
-              ready: false,
-              viewport: null,
-              viewportCount: 0,
-              lastPick: null,
-            };
-          }
-
-          window.__mapTest.lastPick = {
-            layerId: info.layer?.id ?? null,
-            objectId: (info.object as { id?: string | number })?.id ?? null,
-            index: info.index,
-          };
-        }}
-      >
-        <symbolLayer
-          id='symbols'
-          data={SYMBOL_DATA}
-          defaultSymbolOptions={{ colorMode: 'Dark', square: true }}
-          pickable
-        />
-      </BaseMap>
-      <MapTestBridge />
-    </>
+    <MapExample>
+      <symbolLayer
+        id='symbols'
+        data={SYMBOL_DATA}
+        defaultSymbolOptions={{ colorMode: 'Dark', square: true }}
+        pickable
+      />
+    </MapExample>
   );
 }

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -84,6 +84,8 @@
     "memlab:report": "npx tsx src/memlab/scripts/generate-report.ts",
     "start": "NODE_ENV=production next start",
     "test": "pnpm vitest --project=unit",
+    "test:integration": "playwright test",
+    "test:integration:headed": "playwright test --headed",
     "visual": "vitest --project=visual --run --no-coverage",
     "visual:update": "vitest --project=visual --run --update --no-coverage"
   },

--- a/apps/next/playwright.config.ts
+++ b/apps/next/playwright.config.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for BaseMap integration tests.
+ *
+ * Runs headless, without slowMo, and relies on a software GL backend
+ * (SwiftShader via ANGLE) so deck.gl/MapLibre can obtain a WebGL2 context in CI
+ * where no real GPU is available.
+ */
+export default defineConfig({
+  testDir: './src/features',
+  testMatch: '**/*.integration.ts',
+
+  fullyParallel: false,
+  workers: 1,
+
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+
+  // Keep the HTML report outside `outputDir` (test-results) so Playwright does
+  // not clear it when writing per-test artifacts.
+  outputDir: 'test-results/integration',
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report/integration', open: 'never' }],
+  ],
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+    viewport: { width: 1280, height: 800 },
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          // Software WebGL so headless Chromium can render deck.gl reliably.
+          args: [
+            '--use-gl=angle',
+            '--use-angle=swiftshader',
+            '--enable-unsafe-swiftshader',
+            '--ignore-gpu-blocklist',
+          ],
+        },
+      },
+    },
+  ],
+
+  // Start the Next.js server before running tests.
+  webServer: {
+    command: process.env.CI ? 'pnpm start' : 'pnpm build && pnpm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: process.env.CI ? 60_000 : 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/apps/next/src/features/map/client.tsx
+++ b/apps/next/src/features/map/client.tsx
@@ -10,22 +10,37 @@
  * governing permissions and limitations under the License.
  */
 
-import 'server-only';
+'use client';
+
+import 'client-only';
 import { uuid } from '@accelint/core';
 import { BaseMap } from '@accelint/map-toolkit/deckgl';
 import { DEFAULT_VIEW_STATE } from '@accelint/map-toolkit/shared/constants';
 import { MapTestBridge } from './test-bridge';
+import type { ReactNode } from 'react';
+import { clsx } from '@accelint/design-foundation/lib/utils';
+
+export type MapClientProps = {
+  children?: ReactNode;
+  className?: string;
+};
 
 const mapId = uuid();
 
-export function MapClient() {
+export function MapClient({
+  children,
+  className,
+}: MapClientProps) {
+
   return (
     <>
       <BaseMap
-        className='fixed top-xxl left-0 right-0 bottom-0'
+        className={clsx(className, 'fixed top-xxl left-0 right-0 bottom-0')}
         id={mapId}
         initialViewState={DEFAULT_VIEW_STATE}
-      />
+      >
+        {children}
+      </BaseMap>
       <MapTestBridge />
     </>
   );

--- a/apps/next/src/features/map/index.tsx
+++ b/apps/next/src/features/map/index.tsx
@@ -10,16 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-import 'server-only';
 import { ErrorComponent } from './error';
 import { LoadingComponent } from './loading';
-import { MapClient } from './server';
+import { MapClient } from './client';
+import type { ReactNode } from 'react';
 
-export function MapExample() {
+export type MapExampleProps = {
+  children?: ReactNode;
+};
+
+export function MapExample({ children }: MapExampleProps) {
   return (
     <ErrorComponent>
       <LoadingComponent>
-        <MapClient />
+        <MapClient>{children}</MapClient>
       </LoadingComponent>
     </ErrorComponent>
   );

--- a/apps/next/src/features/map/map.integration.ts
+++ b/apps/next/src/features/map/map.integration.ts
@@ -11,11 +11,7 @@
  */
 
 import { expect, test } from '@playwright/test';
-// Type-only import pulls in the `Window.__mapTest` global augmentation that the
-// bridge declares, so `page.evaluate` callbacks below are fully typed.
-import type {} from './test-bridge';
 
-// MapLibre renders the (interleaved) deck.gl scene into this canvas.
 const MAP_CANVAS = 'canvas.maplibregl-canvas';
 
 async function waitForMapReady(page: import('@playwright/test').Page) {

--- a/apps/next/src/features/map/map.integration.ts
+++ b/apps/next/src/features/map/map.integration.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+// Type-only import pulls in the `Window.__mapTest` global augmentation that the
+// bridge declares, so `page.evaluate` callbacks below are fully typed.
+import type {} from './test-bridge';
+
+// MapLibre renders the (interleaved) deck.gl scene into this canvas.
+const MAP_CANVAS = 'canvas.maplibregl-canvas';
+
+async function waitForMapReady(page: import('@playwright/test').Page) {
+  await page.waitForFunction(() => window.__mapTest?.ready === true);
+}
+
+function readViewport(page: import('@playwright/test').Page) {
+  return page.evaluate(() => window.__mapTest?.viewport ?? null);
+}
+
+test.describe('BaseMap integration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/map');
+  });
+
+  test('deck.gl initializes over MapLibre with a live WebGL context', async ({
+    page,
+  }) => {
+    const canvas = page.locator(MAP_CANVAS);
+    await expect(canvas).toBeVisible();
+
+    // A real, sized GL context proves deck.gl + MapLibre wired up the canvas.
+    const gl = await canvas.evaluate((el: HTMLCanvasElement) => {
+      const ctx = el.getContext('webgl2') ?? el.getContext('webgl');
+      return { hasContext: ctx !== null, width: el.width, height: el.height };
+    });
+    expect(gl.hasContext).toBe(true);
+    expect(gl.width).toBeGreaterThan(0);
+    expect(gl.height).toBeGreaterThan(0);
+
+    // BaseMap emits its first `map:viewport` once deck finishes loading.
+    await waitForMapReady(page);
+
+    const viewport = await readViewport(page);
+    expect(viewport).not.toBeNull();
+    expect(viewport?.zoom).toBeGreaterThan(0);
+    expect(viewport?.width).toBeGreaterThan(0);
+    expect(viewport?.height).toBeGreaterThan(0);
+  });
+
+  test('camera responds to pan and zoom interaction', async ({ page }) => {
+    await waitForMapReady(page);
+
+    const start = await readViewport(page);
+    expect(start).not.toBeNull();
+
+    const box = await page.locator(MAP_CANVAS).boundingBox();
+    if (!box) {
+      throw new Error('map canvas has no bounding box');
+    }
+
+    const centerX = box.x + box.width / 2;
+    const centerY = box.y + box.height / 2;
+
+    // Drag to pan — the center coordinate should change.
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.down();
+    await page.mouse.move(centerX - 200, centerY - 120, { steps: 12 });
+    await page.mouse.up();
+
+    const startKey = `${start?.latitude.toFixed(4)},${start?.longitude.toFixed(4)}`;
+    await expect
+      .poll(async () => {
+        const view = await readViewport(page);
+        return view
+          ? `${view.latitude.toFixed(4)},${view.longitude.toFixed(4)}`
+          : '';
+      })
+      .not.toBe(startKey);
+
+    // Wheel up to zoom in — zoom should increase.
+    const beforeZoom =
+      (await page.evaluate(() => window.__mapTest?.viewport?.zoom)) ?? 0;
+
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.wheel(0, -600);
+
+    await expect
+      .poll(() => page.evaluate(() => window.__mapTest?.viewport?.zoom ?? 0))
+      .toBeGreaterThan(beforeZoom);
+  });
+});

--- a/apps/next/src/features/map/server.tsx
+++ b/apps/next/src/features/map/server.tsx
@@ -11,18 +11,22 @@
  */
 
 import 'server-only';
-import { uuid } from '@accelint/core'
+import { uuid } from '@accelint/core';
 import { BaseMap } from '@accelint/map-toolkit/deckgl';
 import { DEFAULT_VIEW_STATE } from '@accelint/map-toolkit/shared/constants';
+import { MapTestBridge } from './test-bridge';
 
-const mapId = uuid()
+const mapId = uuid();
 
 export function MapClient() {
   return (
-    <BaseMap
-      className='fixed top-xxl left-0 right-0 bottom-0'
-      id={mapId}
-      initialViewState={DEFAULT_VIEW_STATE}
-    />
+    <>
+      <BaseMap
+        className='fixed top-xxl left-0 right-0 bottom-0'
+        id={mapId}
+        initialViewState={DEFAULT_VIEW_STATE}
+      />
+      <MapTestBridge />
+    </>
   );
 }

--- a/apps/next/src/features/map/symbol-layer.integration.ts
+++ b/apps/next/src/features/map/symbol-layer.integration.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+// Type-only import pulls in the `Window.__mapTest` global augmentation (incl.
+// `lastPick`) declared by the bridge, so `page.evaluate` callbacks are typed.
+import type {} from './test-bridge';
+
+const MAP_CANVAS = 'canvas.maplibregl-canvas';
+
+test.describe('SymbolLayer integration', () => {
+  test('renders on the map and the center symbol is pickable', async ({
+    page,
+  }) => {
+    await page.goto('/map/symbol-layer');
+
+    // Map + deck are ready once the first viewport is emitted.
+    await page.waitForFunction(() => window.__mapTest?.ready === true);
+
+    const box = await page.locator(MAP_CANVAS).boundingBox();
+    if (!box) {
+      throw new Error('map canvas has no bounding box');
+    }
+
+    const centerX = box.x + box.width / 2;
+    const centerY = box.y + box.height / 2;
+
+    // The 'center' symbol sits at the view center → canvas center. Poll the
+    // click because the symbol's icon atlas can finish loading a beat after the
+    // map reports ready; retry until the pick lands on the known feature.
+    await expect
+      .poll(
+        async () => {
+          await page.mouse.click(centerX, centerY);
+          return page.evaluate(
+            () => window.__mapTest?.lastPick?.objectId ?? null,
+          );
+        },
+        { timeout: 15_000 },
+      )
+      .toBe('center');
+
+    // Sanity: the pick resolved to the symbol layer, not some other layer.
+    const pick = await page.evaluate(() => window.__mapTest?.lastPick);
+    expect(pick?.layerId).toContain('symbols');
+    expect(pick?.index).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/next/src/features/map/symbol-layer.integration.ts
+++ b/apps/next/src/features/map/symbol-layer.integration.ts
@@ -11,9 +11,6 @@
  */
 
 import { expect, test } from '@playwright/test';
-// Type-only import pulls in the `Window.__mapTest` global augmentation (incl.
-// `lastPick`) declared by the bridge, so `page.evaluate` callbacks are typed.
-import type {} from './test-bridge';
 
 const MAP_CANVAS = 'canvas.maplibregl-canvas';
 

--- a/apps/next/src/features/map/test-bridge.tsx
+++ b/apps/next/src/features/map/test-bridge.tsx
@@ -52,8 +52,6 @@ declare global {
   }
 }
 
-// Mirrors map-toolkit's (non-exported) MapViewportEvent, built from the public
-// `MapEvents.viewport` name and the bus `Payload` shape so the bus generics line up.
 type MapViewportBusEvent = Payload<typeof MapEvents.viewport, MapTestViewport>;
 
 const EMPTY_HANDLE: MapTestHandle = {

--- a/apps/next/src/features/map/test-bridge.tsx
+++ b/apps/next/src/features/map/test-bridge.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Hypergiant Galactic Systems Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use client';
+
+import { useOn } from '@accelint/bus/react';
+import { MapEvents } from '@accelint/map-toolkit/deckgl';
+import { useEffect } from 'react';
+import type { Payload } from '@accelint/bus';
+
+export type MapTestViewport = {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+  width: number;
+  height: number;
+  bounds?: [number, number, number, number];
+  id: string;
+};
+
+export type MapTestHandle = {
+  ready: boolean;
+  viewport: MapTestViewport | null;
+  viewportCount: number;
+};
+
+declare global {
+  interface Window {
+    __mapTest?: MapTestHandle;
+  }
+}
+
+// Mirrors map-toolkit's (non-exported) MapViewportEvent, built from the public
+// `MapEvents.viewport` name and the bus `Payload` shape so the bus generics line up.
+type MapViewportBusEvent = Payload<typeof MapEvents.viewport, MapTestViewport>;
+
+const EMPTY_HANDLE: MapTestHandle = {
+  ready: false,
+  viewport: null,
+  viewportCount: 0,
+};
+
+/**
+ * Test-only bridge that mirrors BaseMap readiness and live camera state onto
+ * `window.__mapTest` so Playwright integration tests can make deterministic
+ * assertions without scraping the WebGL canvas.
+ *
+ * BaseMap emits `map:viewport` once deck.gl finishes initializing over MapLibre
+ * (see its deck `onLoad` handler), so the first event doubles as the
+ * "deck + maplibre ready" signal, and every later event reflects camera moves.
+ *
+ * This renders nothing and is harmless in any build; it only sets a window
+ * property. It exists for the example app's integration suite — not production.
+ */
+export function MapTestBridge() {
+  // Seed the handle before the first event so tests can poll immediately.
+  useEffect(() => {
+    window.__mapTest ??= { ...EMPTY_HANDLE };
+  }, []);
+
+  useOn<MapViewportBusEvent>(MapEvents.viewport, (event) => {
+    const current = window.__mapTest ?? EMPTY_HANDLE;
+
+    window.__mapTest = {
+      ready: true,
+      viewport: event.payload,
+      viewportCount: current.viewportCount + 1,
+    };
+  });
+
+  return null;
+}

--- a/apps/next/src/features/map/test-bridge.tsx
+++ b/apps/next/src/features/map/test-bridge.tsx
@@ -27,10 +27,22 @@ export type MapTestViewport = {
   id: string;
 };
 
+/** Minimal, structured-cloneable snapshot of a picked feature. */
+export type MapTestPick = {
+  /** id of the deck.gl (sub)layer that was picked, if any. */
+  layerId: string | null;
+  /** `id` of the picked datum, if the click hit a feature. */
+  objectId: string | number | null;
+  /** Picked object index within the layer, or -1 when nothing was hit. */
+  index: number;
+};
+
 export type MapTestHandle = {
   ready: boolean;
   viewport: MapTestViewport | null;
   viewportCount: number;
+  /** Most recent click pick, populated by routes that wire BaseMap `onClick`. */
+  lastPick: MapTestPick | null;
 };
 
 declare global {
@@ -47,6 +59,7 @@ const EMPTY_HANDLE: MapTestHandle = {
   ready: false,
   viewport: null,
   viewportCount: 0,
+  lastPick: null,
 };
 
 /**
@@ -71,6 +84,7 @@ export function MapTestBridge() {
     const current = window.__mapTest ?? EMPTY_HANDLE;
 
     window.__mapTest = {
+      ...current,
       ready: true,
       viewport: event.payload,
       viewportCount: current.viewportCount + 1,

--- a/apps/next/src/features/map/test-bridge.tsx
+++ b/apps/next/src/features/map/test-bridge.tsx
@@ -16,6 +16,7 @@ import { useOn } from '@accelint/bus/react';
 import { MapEvents } from '@accelint/map-toolkit/deckgl';
 import { useEffect } from 'react';
 import type { Payload } from '@accelint/bus';
+import type { MapClickEvent } from '@accelint/map-toolkit/deckgl';
 
 export type MapTestViewport = {
   latitude: number;
@@ -71,6 +72,10 @@ const EMPTY_HANDLE: MapTestHandle = {
  * (see its deck `onLoad` handler), so the first event doubles as the
  * "deck + maplibre ready" signal, and every later event reflects camera moves.
  *
+ * It also mirrors the most recent click pick (emitted on `map:click`) onto
+ * `lastPick`, so any route that drops layers into the shared map gets pick
+ * assertions for free without wiring its own `onClick`.
+ *
  * This renders nothing and is harmless in any build; it only sets a window
  * property. It exists for the example app's integration suite — not production.
  */
@@ -88,6 +93,20 @@ export function MapTestBridge() {
       ready: true,
       viewport: event.payload,
       viewportCount: current.viewportCount + 1,
+    };
+  });
+
+  useOn<MapClickEvent>(MapEvents.click, (event) => {
+    const current = window.__mapTest ?? EMPTY_HANDLE;
+    const { info } = event.payload;
+
+    window.__mapTest = {
+      ...current,
+      lastPick: {
+        layerId: info.layerId ?? null,
+        objectId: (info.object as { id?: string | number })?.id ?? null,
+        index: info.index,
+      },
     };
   });
 


### PR DESCRIPTION
Closes no ticket.

Sets up a handful of really simple tests in playwright for the map, purely for regression (and other) testing. The advantage of having this here is so that as authors are building new MapToolkit features, they can be easily tested in parallel without having to leave the repo. We can also set up durable tests for the camera and initialization that will allow for safer in-place refactoring.

Right now, there are tests to:
- check the map is initialized
- check that the cameras can pan and zoom
- check that a layer can render successfully

No changeset on this one since there are no library changes.

## ✅ Pull Request Checklist

- [x] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [ ] Added changeset (for bug fixes / features).

## 📝 Test Instructions

In order to run the integration tests, first you have to install the browser binaries if you haven't already: `pnpm --filter @apps/next exec playwright install chromium`

Then you can run the two new scripts:
- `pnpm --filter @apps/next run test:integration` (which runs anything with a .integration.ts extension)
- `pnpm --filter @apps/next run test:integration:headed` (so you can see it running in a browser)

Also you can just start the example application with `pnpm --filter @apps/next run dev` and navigate to the page `http://localhost:3000/map/symbol-layer`

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [ ] Testing
- [x] Implementation


<!-- Optionally describe how AI was used and which tools (e.g., Claude, Copilot, ChatGPT) -->

## 💬 Other information
