### PR TITLE
fix(logger): call disableLogging after replacing LogLevelManager in bootstrap

### DIFF
--- a/packages/logger/src/default/bootstrap.test.ts
+++ b/packages/logger/src/default/bootstrap.test.ts
@@ -27,7 +27,8 @@ vi.mock('loglayer', () => ({
       debug: vi.fn(),
       trace: vi.fn(),
       fatal: vi.fn(),
-      withLogLevelManager: vi.fn(),
+      withLogLevelManager: vi.fn().mockReturnThis(),
+      disableLogging: vi.fn(),
     };
   }),
   StructuredTransport: vi.fn(function () {
@@ -324,6 +325,20 @@ describe('bootstrap', () => {
       expect(vi.mocked(LogLayer)).toHaveBeenCalledWith(
         expect.objectContaining({ enabled: false }),
       );
+    });
+
+    test('should call disableLogging when enabled=false to ensure OneWayLogLevelManager respects disabled state', () => {
+      const logger = bootstrap({ enabled: false });
+
+      // Verify disableLogging was called after withLogLevelManager
+      expect(logger.disableLogging).toHaveBeenCalledOnce();
+    });
+
+    test('should not call disableLogging when enabled=true', () => {
+      const logger = bootstrap({ enabled: true });
+
+      // Should not call disableLogging for enabled logger
+      expect(logger.disableLogging).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/logger/src/default/bootstrap.ts
+++ b/packages/logger/src/default/bootstrap.ts
@@ -91,5 +91,11 @@ export function bootstrap({
 
   instance.withLogLevelManager(new OneWayLogLevelManager());
 
+  // If logging was disabled, re-apply disableLogging() to the new LogLevelManager
+  // because LogLayer constructor called disableLogging() before we replaced the manager
+  if (enabled === false) {
+    instance.disableLogging();
+  }
+
   return instance;
 }


### PR DESCRIPTION
## Summary

Fixes a bug where loggers created with `enabled: false` still output logs.

## Problem

When `bootstrap()` creates a `LogLayer` with `enabled: false`, the constructor calls `disableLogging()` on the `DefaultLogLevelManager`. However, `bootstrap()` then immediately replaces it with a fresh `OneWayLogLevelManager` on line 92, which defaults to having all log levels enabled. This causes the disabled state to be lost.

### Root Cause

**packages/logger/src/default/bootstrap.ts:**
```typescript
const instance = new LogLayer({
  // ... config ...
  enabled,  // <- LogLayer constructor calls disableLogging() when this is false
});

instance.withLogLevelManager(new OneWayLogLevelManager());  // <- Replaces the manager!
// The new OneWayLogLevelManager has all levels enabled by default
```

**node_modules/@loglayer/log-level-manager-one-way/dist/index.js:**
```javascript
var OneWayLogLevelManager = class OneWayLogLevelManager {
  logLevelContainer = { status: {
    info: true,    // <- All default to true
    warn: true,
    error: true,
    debug: true,
    trace: true,
    fatal: true
  } };
```

## Solution

Call `disableLogging()` on the instance after replacing the LogLevelManager to ensure the disabled state is preserved on the new manager:

```typescript
instance.withLogLevelManager(new OneWayLogLevelManager());

// If logging was disabled, re-apply disableLogging() to the new LogLevelManager
if (enabled === false) {
  instance.disableLogging();
}
```

## Changes

- **packages/logger/src/default/bootstrap.ts**: Added explicit `disableLogging()` call after `withLogLevelManager()` when `enabled === false`
- **packages/logger/src/default/bootstrap.test.ts**: Added tests to verify `disableLogging()` is called when `enabled=false` and not called when `enabled=true`

## Testing

```typescript
// Before fix: Logs still appear even with enabled: false
const logger = bootstrap({ enabled: false });
logger.error('test'); // <- This would still log!

// After fix: Logs are properly suppressed
const logger = bootstrap({ enabled: false });
logger.error('test'); // <- No output
```

Added unit tests:
- ✅ Verify `disableLogging()` is called when `enabled=false`
- ✅ Verify `disableLogging()` is NOT called when `enabled=true`

## Impact

- **Breaking Change:** No
- **Behavior Change:** Yes - loggers with `enabled: false` will now correctly suppress all log output
- **Migration Required:** No - this fixes the existing API to work as documented
