### PR TITLE
fix: gantt layout update on prop change

### DIFF
--- a/.changeset/sweet-experts-drum.md
+++ b/.changeset/sweet-experts-drum.md
@@ -1,0 +1,5 @@
+---
+"@accelint/design-toolkit": patch
+---
+
+Fixes an issue in the Gantt component where ref-based callbacks would prevent subscriptions from firing whenever callback dependencies changed. This addresses observed layout/display bugs when modifying props.

--- a/packages/design-toolkit/src/components/gantt/hooks/use-layout-subscription/index.test.ts
+++ b/packages/design-toolkit/src/components/gantt/hooks/use-layout-subscription/index.test.ts
@@ -14,7 +14,8 @@ import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { createGanttStoreProvider } from '../../__fixtures__/store-provider';
 import { useGanttStoreApi } from '../../context/store';
-import { useLayoutSubscription } from './index';
+import type { GanttState } from '../../store';
+import { useLayoutSubscription } from '.';
 
 describe('useLayoutSubscription', () => {
   const createRafSpy = () => {
@@ -50,5 +51,89 @@ describe('useLayoutSubscription', () => {
     // One call for initial mount, one for the store update
     expect(rafSpy).toHaveBeenCalledTimes(2);
     expect(callback).toHaveBeenCalledWith(500);
+  });
+
+  it('re-subscribes when callback changes', () => {
+    createRafSpy();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    const wrapper = createGanttStoreProvider({ startTimeMs: 100 });
+
+    const { rerender, result } = renderHook(
+      ({ cb }: { cb: (value: number) => void }) => {
+        const store = useGanttStoreApi();
+        useLayoutSubscription({
+          callback: cb,
+          selector: (state) => state.currentPositionMs,
+        });
+        return store;
+      },
+      { wrapper, initialProps: { cb: callback1 } },
+    );
+
+    expect(callback1).toHaveBeenCalledWith(100);
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Change callback and update store
+    rerender({ cb: callback2 });
+    act(() => {
+      result.current?.setState({ currentPositionMs: 200 });
+    });
+
+    expect(callback2).toHaveBeenCalledWith(200);
+  });
+
+  it('re-subscribes when selector changes', () => {
+    createRafSpy();
+    const callback = vi.fn();
+    const selector1 = (state: GanttState) => state.currentPositionMs;
+    const selector2 = (state: GanttState) => state.currentRowScrollPx;
+    const wrapper = createGanttStoreProvider({ startTimeMs: 100 });
+
+    const { rerender, result } = renderHook(
+      ({ sel }: { sel: (state: GanttState) => number }) => {
+        const store = useGanttStoreApi();
+        useLayoutSubscription({
+          callback,
+          selector: sel,
+        });
+        return store;
+      },
+      { wrapper, initialProps: { sel: selector1 } },
+    );
+
+    expect(callback).toHaveBeenCalledWith(100);
+
+    // Change selector and update store
+    callback.mockClear();
+    rerender({ sel: selector2 });
+    act(() => {
+      result.current?.setState({ currentRowScrollPx: 50 });
+    });
+
+    expect(callback).toHaveBeenCalledWith(50);
+  });
+
+  it('cancels pending animation frames on cleanup', () => {
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+    const cancelRafSpy = vi.spyOn(window, 'cancelAnimationFrame');
+    const callback = vi.fn();
+    const wrapper = createGanttStoreProvider({ startTimeMs: 0 });
+
+    const { unmount } = renderHook(
+      () => {
+        useLayoutSubscription({
+          callback,
+          selector: (state) => state.currentPositionMs,
+        });
+      },
+      { wrapper },
+    );
+
+    expect(rafSpy).toHaveBeenCalled();
+
+    unmount();
+
+    expect(cancelRafSpy).toHaveBeenCalled();
   });
 });

--- a/packages/design-toolkit/src/components/gantt/hooks/use-layout-subscription/index.ts
+++ b/packages/design-toolkit/src/components/gantt/hooks/use-layout-subscription/index.ts
@@ -11,7 +11,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { shallow } from 'zustand/shallow';
 import { useGanttStoreApi } from '../../context/store';
 import type { GanttState } from '../../store';
@@ -26,20 +26,16 @@ export function useLayoutSubscription<T>({
   selector,
 }: UseLayoutSubscriptionProps<T>) {
   const store = useGanttStoreApi();
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
-  const selectorRef = useRef(selector);
-  selectorRef.current = selector;
 
   useEffect(() => {
     let animationFrameId: number;
 
     const unsubscribe = store.subscribe(
-      (state) => selectorRef.current(state),
+      (state) => selector(state),
       (value) => {
         cancelAnimationFrame(animationFrameId);
         animationFrameId = requestAnimationFrame(() => {
-          callbackRef.current(value);
+          callback(value);
         });
       },
       {
@@ -59,5 +55,5 @@ export function useLayoutSubscription<T>({
       cancelAnimationFrame(animationFrameId);
       unsubscribe();
     };
-  }, [store]);
+  }, [store, callback, selector]);
 }


### PR DESCRIPTION
Fixes an issue in the Gantt component where ref-based callbacks would preent subscriptions from firing when callback dependencies changed. This address observed layout/display bugs when modifying props.

## ✅ Pull Request Checklist

- [ ] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
- [ ] Added/updated visual regression tests for this change (for bug fixes / features).
- [ ] Added/updated documentation (for bug fixes / features)
- [x] Filled out test instructions.
- [x] Added changeset (for bug fixes / features).

## 📝 Test Instructions

- Open Gantt component story.
- Change timescale to 24h to cause entirety of data to be displayed.
- Change timescale to 1h or less.
- The Gantt component's displayed elements should update as expected to reflect the latest timescale value.

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

<!-- If any AI is used use the AI label, if the work was 100% human use the Human label -->
- [x] Added corresponding label (ai / human) to PR:

If ai was used, select all that apply:
- [ ] Ideation / brainstorming
- [ ] Documentation
- [x] Testing
- [ ] Implementation


Used Claude to add test coverage for this change.

## 💬 Other information

### Before

https://github.com/user-attachments/assets/82754c27-3c0c-4055-9253-3e2e4b9105c5

### After

https://github.com/user-attachments/assets/2e09fe2c-e992-4a34-905d-e80036038c8a

