### PR TITLE
chore: allow undefined values in lookup

### DIFF
--- a/packages/core/src/utility/lookup/index.test.ts
+++ b/packages/core/src/utility/lookup/index.test.ts
@@ -56,8 +56,22 @@ describe('tableLookup', () => {
   it('should use identity for undefined default', () => {
     const actualOne = undefLookup('UNKNOWN');
     const actualTwo = undefLookup('BAR');
+    const actualThree = undefLookup('TEST');
 
     expect(actualOne).not.toBeDefined();
     expect(actualTwo).toEqual(colorTable.BAR);
+    expect(actualThree).toEqual(null);
+  });
+
+  it('should use default for for a null or undefined props', () => {
+    const actualOne = colorLookup(undefined);
+
+    expect(actualOne).toEqual(defaultColor);
+  });
+
+  it('should use identity  for for a null or undefined props', () => {
+    const actualOne = undefLookup(undefined);
+
+    expect(actualOne).toEqual(undefined);
   });
 });

--- a/packages/core/src/utility/lookup/index.ts
+++ b/packages/core/src/utility/lookup/index.ts
@@ -39,17 +39,15 @@ import { identity } from '../../combinators/identity';
  * colorLookup(data.value);
  * ```
  */
-export const lookup =
-  <
-    A extends Record<string | number | symbol, unknown>,
-    // biome-ignore lint/suspicious/noExplicitAny: This is intended
-    B extends (...args: any[]) => any,
-  >(
-    obj: A,
-    def?: B,
-  ) =>
-  <C extends keyof A>(prop: string | number | symbol): A[C] => {
-    const fn = def ?? identity;
-
-    return fn(obj[prop]);
-  };
+export const lookup = <
+  A extends Record<PropertyKey, unknown>,
+  // biome-ignore lint/suspicious/noExplicitAny: This is intended
+  B extends (...args: any[]) => any,
+>(
+  obj: A,
+  def?: B,
+) => {
+  const fn = def ?? identity;
+  return <C extends keyof A>(prop: PropertyKey | null | undefined): A[C] =>
+    fn(prop == null ? undefined : obj[prop]);
+};


### PR DESCRIPTION
- Allow null | undefined in lookup function calls.

You can see the TS error if you add the explicit undefined params test cases to 'main'.

The 
`const fn = def ?? identity` 
move is to lift that assignment to the time of creation, rather than time of call

```typescript
const TABLE = {
 'FIRST': 'HELLO',
 'SECOND': 'WORLD'
}

const tableLookup = lookup(TABLE, x => x ?? 'MISSING')

/* ------------------- */

// Let's assume 'value' corresponds to "FIRST" or "SECOND"
// but it's also nullable
type MyData = {
  value?: string,
  id: string,
}

// we get this data from an external source; if the source says nullable
// data.value could be undefined|null
const data: MyData = fetch(...)

//    a representative/mocked return might be:
// const mockMyData: MyData = {
//   id: '1234',
// }
//


// before this PR - ts-error 
//Argument of type 'string | undefined' is not assignable to parameter of type 'string | number | symbol'.
//   Type 'undefined' is not assignable to type 'string | number | symbol'
//
// but it 'works', because Javascript coerces obj[undefined] to obj['undefined']
// y = 'HELLO' | 'WORLD' | 'MISSING'

const y = tableLookup(data.value)

// after this PR - no type error; y = 'HELLO'|'WORLD'|'MISSING'


const nofallbackLookup = lookup(TABLE);
const z = nofallbackLookup(data.value)
// z = 'HELLO' | 'WORLD' | undefined

```

## ✅ Pull Request Checklist

- [NA] Included link to corresponding [GitHub Issue](https://github.com/gohypergiant/standard-toolkit/issues).
- [x] The commit message follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) [extended](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) guidelines.
- [x] Added/updated unit tests and storybook for this change (for bug fixes / features).
~~- [ ] Added/updated visual regression tests for this change (for bug fixes / features).~~
~~- [ ] Added/updated documentation (for bug fixes / features)~~
~~- [ ] Filled out test instructions.~~
~~- [ ] Added changeset (for bug fixes / features).~~

## 📝 Test Instructions

<!--- Include instructions to test this pull request -->
Run core package tests

## ❓ Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## 🤖 AI Usage

100% human

## 💬 Other information
